### PR TITLE
Allow Patterns to be skipped in matching memoization, Results to be skipped in printing results tree

### DIFF
--- a/Packrat Parsing/bin/.gitignore
+++ b/Packrat Parsing/bin/.gitignore
@@ -1,3 +1,4 @@
 /structure/
 /patterns/
 /util/
+/controller/

--- a/Packrat Parsing/src/controller/PackratDriver.java
+++ b/Packrat Parsing/src/controller/PackratDriver.java
@@ -1,6 +1,6 @@
 package controller;
 
-import patterns.definition.SimpleExpression;
+import patterns.definition.DefinitionExpression;
 import patterns.general.Pattern;
 import structure.InputContext;
 import structure.Result;
@@ -21,14 +21,21 @@ public class PackratDriver {
 		final InputContext input = new InputContext(TEST_STRING);
 
 		// Create the pattern
-		final Pattern matcher = new SimpleExpression();
+		final Pattern matcher = new DefinitionExpression();
 
 		// Attempt to match
 		final Result result = matcher.lazyMatch(input);
 
 		// Print out the result
 		System.out.println(result.toString());
+
+		System.out.println("Hidden tree:");
 		System.out.println(result.printResultTree());
+		System.out.println("\n\n\n\n\n");
+
+		System.out.println("Full tree:");
+		System.out.println(result.printResultTree(true));
+		System.out.println("\n\n\n\n\n");
 
 	}
 }

--- a/Packrat Parsing/src/patterns/definition/DefinitionExpression.java
+++ b/Packrat Parsing/src/patterns/definition/DefinitionExpression.java
@@ -15,16 +15,18 @@ public class DefinitionExpression extends PatternDefinition {
 
 	/** Internal definition used when matching. */
 	private final Pattern pattern = new PatternChoice(
-			new PatternSequence(this, new PatternString("+"), new DefinitionNumber()),
-			new DefinitionNumber()
-			);
+			new PatternSequence(this, new PatternString("+"), new DefinitionNumber()), new DefinitionNumber());
+	/** Pattern type to provide the display or reference name. */
+	private static final String TYPE = "Expression";
 
-	/**
-	 * Returns the pattern we create in Expression.
-	 */
 	@Override
 	protected Pattern getDefinition() {
 		return pattern;
+	}
+
+	@Override
+	public String getType() {
+		return TYPE;
 	}
 
 }

--- a/Packrat Parsing/src/patterns/definition/DefinitionNumber.java
+++ b/Packrat Parsing/src/patterns/definition/DefinitionNumber.java
@@ -7,14 +7,19 @@ import patterns.general.PatternRepetition;
 public class DefinitionNumber extends PatternDefinition {
 
 	/** Pattern definition states that a number is one or more Digits. */
-	private static final PatternRepetition number = new PatternRepetition(new PatternDigit(), 1, -1);
+	private static final PatternRepetition NUMBER = new PatternRepetition(new PatternDigit(), 1, -1);
 
-	/**
-	 * Returns the pattern we define.
-	 */
+	/** Pattern type to indicate display and reference name. */
+	private static final String TYPE = "Number";
+
 	@Override
 	protected Pattern getDefinition() {
-		return number;
+		return NUMBER;
+	}
+
+	@Override
+	public String getType() {
+		return TYPE;
 	}
 
 }

--- a/Packrat Parsing/src/patterns/definition/PatternDefinition.java
+++ b/Packrat Parsing/src/patterns/definition/PatternDefinition.java
@@ -4,7 +4,7 @@
 package patterns.definition;
 
 import patterns.general.Pattern;
-import structure.Derivation;
+import structure.InputContext;
 import structure.Result;
 
 /**
@@ -18,9 +18,9 @@ public abstract class PatternDefinition extends Pattern {
 	 * provided.
 	 */
 	@Override
-	protected Result match(Derivation derivation) {
+	protected Result match(final InputContext context) {
 		// Delegate to the pattern we created.
-		return getDefinition().lazyMatch(derivation);
+		return getDefinition().lazyMatch(context);
 	}
 
 	/**
@@ -36,8 +36,8 @@ public abstract class PatternDefinition extends Pattern {
 	 */
 	@Override
 	public int hashCode() {
-		int prime = 31;
-		int hash = prime * super.hashCode() + super.getID();
+		final int prime = 31;
+		final int hash = (prime * super.hashCode()) + super.getID();
 		return hash;
 	}
 
@@ -45,16 +45,20 @@ public abstract class PatternDefinition extends Pattern {
 	 * Definitions are always compared by instance and ID.
 	 */
 	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
+	public boolean equals(final Object obj) {
+		if (this == obj) {
 			return true;
-		if (!super.equals(obj))
+		}
+		if (!super.equals(obj)) {
 			return false;
-		if (getClass() != obj.getClass())
+		}
+		if (getClass() != obj.getClass()) {
 			return false;
-		PatternDefinition other = (PatternDefinition) obj;
-		if (this.getID() != other.getID())
+		}
+		final PatternDefinition other = (PatternDefinition) obj;
+		if (this.getID() != other.getID()) {
 			return false;
+		}
 		return true;
 	}
 

--- a/Packrat Parsing/src/patterns/definition/SimpleExpression.java
+++ b/Packrat Parsing/src/patterns/definition/SimpleExpression.java
@@ -8,6 +8,8 @@ public class SimpleExpression extends Pattern {
 
 	private static final SimpleNumber num = new SimpleNumber();
 
+	private static final String TYPE = "Expression";
+
 	@Override
 	protected Result match(final InputContext context) {
 		Result result;
@@ -108,6 +110,16 @@ public class SimpleExpression extends Pattern {
 	@Override
 	public boolean equals(final Object obj) {
 		return this == obj;
+	}
+
+	/**
+	 * Returns the type (name) of this Pattern.
+	 * 
+	 * @return the String type of this Pattern
+	 */
+	@Override
+	public String getType() {
+		return TYPE;
 	}
 
 }

--- a/Packrat Parsing/src/patterns/definition/SimpleExpression.java
+++ b/Packrat Parsing/src/patterns/definition/SimpleExpression.java
@@ -55,10 +55,8 @@ public class SimpleExpression extends Pattern {
 		if (!result.isSuccess()) {
 			return result;
 		}
-		// Successful match. Add the child result to the overall Expression children and
-		// append its data
+		// Successful match. Add the child result to the overall Expression result
 		expression.addChild(result);
-		expression.setData(expression.getData() + result.getData());
 
 		// Match plus
 		result = this.matchPlus(context);
@@ -68,7 +66,7 @@ public class SimpleExpression extends Pattern {
 		}
 		// Successful match. Append the child match's data
 		// TODO: Add the child result and flag it as "invisible"?
-		expression.setData(expression.getData() + result.getData());
+		expression.addChild(result);
 
 		// Match Num
 		result = num.lazyMatch(context);
@@ -76,17 +74,13 @@ public class SimpleExpression extends Pattern {
 		if (!result.isSuccess()) {
 			return result;
 		}
-		// Successful match. Add the child result to the overall Expression children and
-		// append its data
+		// Successful match. Add the child result to the overall Expression result
 		expression.addChild(result);
-		expression.setData(expression.getData() + result.getData());
-
-		expression.setEndIdx(result.getEndIdx());
 		return expression;
 	}
 
 	private Result matchPlus(final InputContext context) {
-		if (!context.atEnd() && context.currentDeriv().getChResult().isSuccess()
+		if (!context.isAtEnd() && context.currentDeriv().getChResult().isSuccess()
 				&& (context.currentDeriv().getChResult().getData().charAt(0) == '+')) {
 			System.out.println("Matched [" + context.currentDeriv().getChResult().getData() + "]");
 			context.advance();

--- a/Packrat Parsing/src/patterns/definition/SimpleNumber.java
+++ b/Packrat Parsing/src/patterns/definition/SimpleNumber.java
@@ -6,6 +6,9 @@ import structure.Result;
 
 public class SimpleNumber extends Pattern {
 
+	/** The Type of this pattern (display/reference name) */
+	private static final String TYPE = "Number";
+
 	@Override
 	protected Result match(final InputContext context) {
 		if (!context.currentDeriv().getChResult().isSuccess()
@@ -14,7 +17,7 @@ public class SimpleNumber extends Pattern {
 		}
 
 		final Result priorResult = new Result(true, context.currentChar(), context.getPosition());
-		priorResult.setType("Number");
+//		priorResult.setType("Number");
 
 		char match = context.next();
 
@@ -51,6 +54,14 @@ public class SimpleNumber extends Pattern {
 	@Override
 	public boolean equals(final Object obj) {
 		return this == obj;
+	}
+
+	/**
+	 * Provides the Type of this pattern
+	 */
+	@Override
+	public String getType() {
+		return TYPE;
 	}
 
 }

--- a/Packrat Parsing/src/patterns/general/Pattern.java
+++ b/Packrat Parsing/src/patterns/general/Pattern.java
@@ -124,7 +124,7 @@ public abstract class Pattern {
 	public final Result lazyMatch(final InputContext context) {
 
 		// If context is at its end, reject
-		if (context.atEnd()) {
+		if (context.isAtEnd()) {
 			return Result.FAIL();
 		}
 

--- a/Packrat Parsing/src/patterns/general/Pattern.java
+++ b/Packrat Parsing/src/patterns/general/Pattern.java
@@ -123,11 +123,6 @@ public abstract class Pattern {
 	 */
 	public final Result lazyMatch(final InputContext context) {
 
-		// If context is at its end, reject
-		if (context.isAtEnd()) {
-			return Result.FAIL();
-		}
-
 		// If this pattern has no Type or is an alias, delegate immediately to match()
 		if ((this.getType() == null) || this.isAlias()) {
 

--- a/Packrat Parsing/src/patterns/general/PatternChoice.java
+++ b/Packrat Parsing/src/patterns/general/PatternChoice.java
@@ -6,14 +6,14 @@ package patterns.general;
 import java.util.ArrayList;
 import java.util.List;
 
-import structure.Derivation;
+import structure.InputContext;
 import structure.Result;
 
 /**
  * @author Melody Griesen
  *
  */
-public class PatternChoice extends Pattern {
+public class PatternChoice extends PatternComponent {
 
 	/** List of patterns to match in ordered choice alternatives. */
 	private List<Pattern> patterns;
@@ -29,10 +29,11 @@ public class PatternChoice extends Pattern {
 	 * 
 	 * @param patterns the set of possible patterns to choose from
 	 */
-	public PatternChoice(Pattern... patterns) {
+	public PatternChoice(final Pattern... patterns) {
 		// For each Pattern in the list, add it to the ArrayList
-		for (Pattern p : patterns)
+		for (final Pattern p : patterns) {
 			this.patterns.add(p);
+		}
 	}
 
 	/**
@@ -41,7 +42,7 @@ public class PatternChoice extends Pattern {
 	 * 
 	 * @param patterns the set of possible patterns to choose from
 	 */
-	public PatternChoice(List<Pattern> patterns) {
+	public PatternChoice(final List<Pattern> patterns) {
 		this.patterns.addAll(patterns);
 	}
 
@@ -53,7 +54,7 @@ public class PatternChoice extends Pattern {
 	 *              failed
 	 * @return this PatternChoice object for multiple chainings of this method
 	 */
-	public PatternChoice add(Pattern toAdd) {
+	public PatternChoice add(final Pattern toAdd) {
 		// Add the new pattern to the end of the list
 		patterns.add(toAdd);
 		// Return this object for method chaining
@@ -70,22 +71,31 @@ public class PatternChoice extends Pattern {
 	 *         of them do
 	 */
 	@Override
-	protected Result match(Derivation derivation) {
+	protected Result match(final InputContext context) {
+		// Track the initial starting position
+		final Result choice = new Result(true, "", context.getPosition());
+
 		// Run through the list of patterns to match
 		// Keep track of the previous pattern's result
 		Result result;
 		// Loop over all patterns
-		for (Pattern p : patterns) {
+		for (final Pattern p : patterns) {
+
 			// Attempt to match this pattern
-			result = p.lazyMatch(derivation);
-			// If success, return it
-			if (result.isSuccess())
-				return result;
-			// Otherwise, try the next pattern instead.
+			result = p.lazyMatch(context);
+
+			// If success, save and return the choice result
+			if (result.isSuccess()) {
+				choice.addChild(result);
+				return choice;
+			}
+
+			// Otherwise, try the next pattern instead. Reset the context!
+			context.setPosition(choice.getStartIdx());
 		}
 
 		// Looped over all patterns successfully, none matched. Send it back!
-		return new Result(false, null, null);
+		return Result.FAIL();
 	}
 
 	/**
@@ -95,27 +105,33 @@ public class PatternChoice extends Pattern {
 	public int hashCode() {
 		final int prime = 31;
 		int result = super.hashCode();
-		result = prime * result + ((patterns == null) ? 0 : patterns.hashCode());
+		result = (prime * result) + ((patterns == null) ? 0 : patterns.hashCode());
 		return result;
 	}
 
 	/**
-	 * Declares that two PatternChoice objects are only equal if they have the same sequence of Patterns.
+	 * Declares that two PatternChoice objects are only equal if they have the same
+	 * sequence of Patterns.
 	 */
 	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
+	public boolean equals(final Object obj) {
+		if (this == obj) {
 			return true;
-		if (!super.equals(obj))
+		}
+		if (!super.equals(obj)) {
 			return false;
-		if (getClass() != obj.getClass())
+		}
+		if (getClass() != obj.getClass()) {
 			return false;
-		PatternChoice other = (PatternChoice) obj;
+		}
+		final PatternChoice other = (PatternChoice) obj;
 		if (patterns == null) {
-			if (other.patterns != null)
+			if (other.patterns != null) {
 				return false;
-		} else if (!patterns.equals(other.patterns))
+			}
+		} else if (!patterns.equals(other.patterns)) {
 			return false;
+		}
 		return true;
 	}
 

--- a/Packrat Parsing/src/patterns/general/PatternComponent.java
+++ b/Packrat Parsing/src/patterns/general/PatternComponent.java
@@ -1,0 +1,28 @@
+/**
+ * 
+ */
+package patterns.general;
+
+/**
+ * Allows for components of Patterns that skip memoization and result printing
+ * to be built by extending from this class.
+ * 
+ * This allows for component classes that implement operations like
+ * alternations, sequences, predicates, etc. without interfering with direct
+ * left recursion or printing extra entries to the Results tree.
+ * 
+ * @author Melody Griesen
+ *
+ */
+public abstract class PatternComponent extends Pattern {
+
+	/**
+	 * Signals to Pattern that this object should not be considered for memoization
+	 * or produce Results that should be printed in the output tree.
+	 */
+	@Override
+	public String getType() {
+		return null;
+	}
+
+}

--- a/Packrat Parsing/src/patterns/general/PatternDigit.java
+++ b/Packrat Parsing/src/patterns/general/PatternDigit.java
@@ -3,30 +3,32 @@
  */
 package patterns.general;
 
-import structure.Derivation;
+import structure.InputContext;
 import structure.Result;
 
 /**
  * @author Melody Griesen
  *
  */
-public class PatternDigit extends Pattern {
+public class PatternDigit extends PatternComponent {
 
 	/**
 	 * Matches a single digit as determeind by Character.isDigit()
 	 */
 	@Override
-	protected Result match(Derivation derivation) {
+	protected Result match(final InputContext context) {
 		// Ensure input remaining
-		if(!derivation.getChResult().isSuccess())
+		if (context.isAtEnd()) {
 			return Result.FAIL();
+		}
 		// Retrieve character
-		char ch = derivation.getChResult().getData().charAt(0);
+		final char ch = context.currentChar();
 		// Determines if the derivation character is a digit
-		if(Character.isDigit(ch)) {
+		if (Character.isDigit(ch)) {
 			// Is a digit! Success
 			System.out.println("Matched [" + ch + "]");
-			return new Result(true, "" + ch, derivation.getChResult().getDerivation());
+			context.advance();
+			return new Result(true, ch, context.getPosition() - 1);
 		} else {
 			// Not a digit. Failure
 			return Result.FAIL();

--- a/Packrat Parsing/src/patterns/general/PatternRepetition.java
+++ b/Packrat Parsing/src/patterns/general/PatternRepetition.java
@@ -3,78 +3,93 @@
  */
 package patterns.general;
 
-import structure.Derivation;
+import structure.InputContext;
 import structure.Result;
 
 /**
  * @author Melody Griesen
  *
  */
-public class PatternRepetition extends Pattern {
+public class PatternRepetition extends PatternComponent {
 
 	/** Minimum number of times that the pattern must be present to match. */
-	private int lowerBound;
+	private final int lowerBound;
 	/** Maximum number of times that the pattern will match. If -1, no max limit. */
-	private int upperBound;
+	private final int upperBound;
 	/** Pattern to repeat. */
-	private Pattern pattern;
+	private final Pattern pattern;
 
 	/**
 	 * A PatternRepetition must be constructed with a given pattern to repeat, as
 	 * well as the lower and upper bounds for the repetition.
 	 * 
-	 * @param pattern the pattern to match
+	 * @param pattern    the pattern to match
 	 * @param lowerBound the minimum number of times that the pattern must match
 	 * @param upperBound the maximum number of times that the pattern may match
 	 */
-	public PatternRepetition(Pattern pattern, int lowerBound, int upperBound) {
+	public PatternRepetition(final Pattern pattern, final int lowerBound, final int upperBound) {
+		if (pattern == null) {
+			throw new IllegalArgumentException("Pattern for Repetition cannot be null!");
+		}
+		if (lowerBound < 0) {
+			throw new IllegalArgumentException("Lower bound for Repetition cannot be negative!");
+		}
+		if (upperBound < -1) {
+			throw new IllegalArgumentException("Upper bound for Repetition cannot be below -1!");
+		}
 		this.pattern = pattern;
 		this.lowerBound = lowerBound;
 		this.upperBound = upperBound;
 	}
 
 	/**
-	 * Matches a sequence of instances of the Pattern, with upper and lower bounds specified by fields.
+	 * Matches a sequence of instances of the Pattern, with upper and lower bounds
+	 * specified by fields.
 	 */
 	@Override
-	protected Result match(Derivation derivation) {
-		// Track the previous result so that we know where to start each loop from and what to return if we fail
-		Result previousResult = new Result(true, null, derivation);
+	protected Result match(final InputContext context) {
+		// Create an overall result to track starting position
+		final Result repetition = new Result(true, "", context.getPosition());
 		// Track the number of successful iterations
 		int matches = 0;
-		// Begin iterating over the Derivation
-		while(matches != upperBound) {
+
+		// Begin iterating over the context
+		while (matches != upperBound) {
+
 			// Attempt to match at this iteration
-			Result result = pattern.lazyMatch(previousResult.getDerivation());
-			
+			final Result result = pattern.lazyMatch(context);
+
 			// If we succeeded in matching
-			if(result.isSuccess()) {
+			if (result.isSuccess()) {
 				// Increment our match count
 				matches++;
-				// Save as previous result
-				previousResult = result;
+				// Add as a child of our matches
+				repetition.addChild(result);
 			}
 			// Otherwise, we failed in matching
 			else {
 				// Did we meet the minimum count?
-				if(matches >= lowerBound) {
+				if (matches >= lowerBound) {
 					// If yes, return a success
-					return previousResult;
+					return repetition;
 				}
 				// We did not meet the minimum count.
 				else {
+					// Reset the context
+					context.setPosition(repetition.getStartIdx());
 					// Return a failure.
 					return Result.FAIL();
 				}
 			}
 		}
-		
+
 		// We exited matching because we reached our maximum number of matches. Success!
-		return previousResult;
+		return repetition;
 	}
 
 	/**
-	 * A PatternRepetition is declared unique by all of its fields - Pattern, lower bound, and upper bound.
+	 * A PatternRepetition is declared unique by all of its fields - Pattern, lower
+	 * bound, and upper bound.
 	 * 
 	 * @return a unique hashCode for this PatternRepetition
 	 */
@@ -82,36 +97,42 @@ public class PatternRepetition extends Pattern {
 	public int hashCode() {
 		final int prime = 31;
 		int result = super.hashCode();
-		result = prime * result + lowerBound;
-		result = prime * result + ((pattern == null) ? 0 : pattern.hashCode());
-		result = prime * result + upperBound;
+		result = (prime * result) + lowerBound;
+		result = (prime * result) + ((pattern == null) ? 0 : pattern.hashCode());
+		result = (prime * result) + upperBound;
 		return result;
 	}
 
 	/**
-	 * Declares that PatternRepetitions are equal if their pattern, lower bound, and upper bound match.
+	 * Declares that PatternRepetitions are equal if their pattern, lower bound, and
+	 * upper bound match.
 	 */
 	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
+	public boolean equals(final Object obj) {
+		if (this == obj) {
 			return true;
-		if (!super.equals(obj))
+		}
+		if (!super.equals(obj)) {
 			return false;
-		if (getClass() != obj.getClass())
+		}
+		if (getClass() != obj.getClass()) {
 			return false;
-		PatternRepetition other = (PatternRepetition) obj;
-		if (lowerBound != other.lowerBound)
+		}
+		final PatternRepetition other = (PatternRepetition) obj;
+		if (lowerBound != other.lowerBound) {
 			return false;
+		}
 		if (pattern == null) {
-			if (other.pattern != null)
+			if (other.pattern != null) {
 				return false;
-		} else if (!pattern.equals(other.pattern))
+			}
+		} else if (!pattern.equals(other.pattern)) {
 			return false;
-		if (upperBound != other.upperBound)
+		}
+		if (upperBound != other.upperBound) {
 			return false;
+		}
 		return true;
 	}
-	
-	
 
 }

--- a/Packrat Parsing/src/patterns/general/PatternSequence.java
+++ b/Packrat Parsing/src/patterns/general/PatternSequence.java
@@ -6,14 +6,14 @@ package patterns.general;
 import java.util.ArrayList;
 import java.util.List;
 
-import structure.Derivation;
+import structure.InputContext;
 import structure.Result;
 
 /**
  * @author Melody Griesen
  *
  */
-public class PatternSequence extends Pattern {
+public class PatternSequence extends PatternComponent {
 
 	/** List of patterns to match one after another. */
 	private List<Pattern> patterns;
@@ -29,10 +29,11 @@ public class PatternSequence extends Pattern {
 	 * 
 	 * @param patterns the sequence of patterns to match
 	 */
-	public PatternSequence(Pattern... patterns) {
+	public PatternSequence(final Pattern... patterns) {
 		// For each Pattern in the list, add it to the ArrayList
-		for (Pattern p : patterns)
+		for (final Pattern p : patterns) {
 			this.patterns.add(p);
+		}
 	}
 
 	/**
@@ -41,7 +42,7 @@ public class PatternSequence extends Pattern {
 	 * 
 	 * @param patterns the sequence of patterns to match
 	 */
-	public PatternSequence(List<Pattern> patterns) {
+	public PatternSequence(final List<Pattern> patterns) {
 		this.patterns.addAll(patterns);
 	}
 
@@ -52,7 +53,7 @@ public class PatternSequence extends Pattern {
 	 * @param toAdd the new pattern to match after all previous patterns
 	 * @return this PatternSequence object for multiple chainings of this method
 	 */
-	public PatternSequence add(Pattern toAdd) {
+	public PatternSequence add(final Pattern toAdd) {
 		// Add the new pattern to the end of the list
 		patterns.add(toAdd);
 		// Return this object for method chaining
@@ -69,25 +70,29 @@ public class PatternSequence extends Pattern {
 	 *         if failure
 	 */
 	@Override
-	protected Result match(Derivation derivation) {
+	protected Result match(final InputContext context) {
 		// Run through the list of patterns to match
 		// Keep track of the previous pattern's result
-		Result result = new Result(true, null, derivation);
+		final Result sequence = new Result(true, "", context.getPosition());
+		Result result;
 		// Loop over all patterns
-		for (Pattern p : patterns) {
+		for (final Pattern p : patterns) {
 			// Attempt to match this pattern
-			result = p.lazyMatch(result.getDerivation());
+			result = p.lazyMatch(context);
 			// If fail, return it
-			if (!result.isSuccess())
+			if (!result.isSuccess()) {
+				// Reset the context first
+				context.setPosition(sequence.getStartIdx());
 				return result;
-			// Otherwise, use its result to try the next one.
+				// Otherwise, use its result to try the next one.
+			}
+			// Otherwise, add its contents into the Result
+			sequence.addChild(result);
 		}
 
 		// Looped over all patterns successfully. Send result!
-		return result;
+		return sequence;
 	}
-	
-
 
 	/**
 	 * Assigns a unique hash code based on the contents of the patterns list.
@@ -96,27 +101,33 @@ public class PatternSequence extends Pattern {
 	public int hashCode() {
 		final int prime = 31;
 		int result = super.hashCode();
-		result = prime * result + ((patterns == null) ? 0 : patterns.hashCode());
+		result = (prime * result) + ((patterns == null) ? 0 : patterns.hashCode());
 		return result;
 	}
 
 	/**
-	 * Declares that two PatternSequence objects are only equal if they have the same sequence of Patterns.
+	 * Declares that two PatternSequence objects are only equal if they have the
+	 * same sequence of Patterns.
 	 */
 	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
+	public boolean equals(final Object obj) {
+		if (this == obj) {
 			return true;
-		if (!super.equals(obj))
+		}
+		if (!super.equals(obj)) {
 			return false;
-		if (getClass() != obj.getClass())
+		}
+		if (getClass() != obj.getClass()) {
 			return false;
-		PatternSequence other = (PatternSequence) obj;
+		}
+		final PatternSequence other = (PatternSequence) obj;
 		if (patterns == null) {
-			if (other.patterns != null)
+			if (other.patterns != null) {
 				return false;
-		} else if (!patterns.equals(other.patterns))
+			}
+		} else if (!patterns.equals(other.patterns)) {
 			return false;
+		}
 		return true;
 	}
 

--- a/Packrat Parsing/src/patterns/general/PatternString.java
+++ b/Packrat Parsing/src/patterns/general/PatternString.java
@@ -3,24 +3,24 @@
  */
 package patterns.general;
 
-import structure.Derivation;
+import structure.InputContext;
 import structure.Result;
 
 /**
  * @author Melody Griesen
  *
  */
-public class PatternString extends Pattern {
+public class PatternString extends PatternComponent {
 
 	/** The string we're expecting to match. */
-	private String matchString;
+	private final String matchString;
 
 	/**
 	 * Constructs a PatternString with a string to match.
 	 * 
 	 * @param matchString
 	 */
-	public PatternString(String matchString) {
+	public PatternString(final String matchString) {
 		this.matchString = matchString;
 	}
 
@@ -28,44 +28,42 @@ public class PatternString extends Pattern {
 	 * Matches this pattern string by recursively matching one character at a time.
 	 */
 	@Override
-	protected Result match(Derivation derivation) {
-		// Use recursive helper
-		Result match = matchRemaining(matchString, derivation);
-		if (match.isSuccess()) {
-			// Success
-			match.setData(matchString);
-		}
-		return match;
-	}
+	protected Result match(final InputContext context) {
 
-	/**
-	 * Recursive method that matches a sequence of characters.
-	 * 
-	 * @param remainingPattern the String to match
-	 * @param remainingInput   the input to match against
-	 * @return a Result with empty value indicating a true/false match and, if true,
-	 *         the derivation we ended at.
-	 */
-	private Result matchRemaining(String remainingPattern, Derivation remainingInput) {
-		// Base case
-		if ("".equals(remainingPattern)) {
-			return new Result(true, null, remainingInput);
-		}
-		// Recursive case
-		else {
-			// Match the one character
-			if (remainingInput.getChResult().isSuccess()
-					&& remainingPattern.charAt(0) == remainingInput.getChResult().getData().charAt(0)) {
-				// Success
-				System.out.println("Matched [" + remainingPattern.charAt(0) + "]");
-				return matchRemaining(remainingPattern.substring(1), remainingInput.getChResult().getDerivation());
-			} else {
-				// Failure
-				System.out.println("Failed to match " + remainingPattern.charAt(0));
+		// Save initial position
+		final int initialPosition = context.getPosition();
+
+		// Use iterative solution
+		final Result match = new Result(true, "", initialPosition);
+
+		// Loop for each character of the target string
+		for (final char c : matchString.toCharArray()) {
+			// If the next character matches, accept
+			if (!context.isAtEnd() && (c == context.next())) {
+				// Add character to Result
+				match.addChar(c);
+				System.out.println("Matched [" + c + "]");
+			}
+			// Else, character doesn't match.
+			else {
+				// Pack up, go home.
+				// Reset context back to start
+				context.setPosition(initialPosition);
+				// Return failure
 				return Result.FAIL();
 			}
 		}
 
+		// Return successful match
+		return match;
+	}
+
+	/**
+	 * Generates a display string that shows the PatternString's match string
+	 */
+	@Override
+	public String toString() {
+		return "PatternString [matchString=" + matchString + "]";
 	}
 
 	/**
@@ -75,7 +73,7 @@ public class PatternString extends Pattern {
 	public int hashCode() {
 		final int prime = 31;
 		int result = super.hashCode();
-		result = prime * result + ((matchString == null) ? 0 : matchString.hashCode());
+		result = (prime * result) + ((matchString == null) ? 0 : matchString.hashCode());
 		return result;
 	}
 
@@ -83,19 +81,24 @@ public class PatternString extends Pattern {
 	 * Declares that two PatternString objects are equal if their String matches.
 	 */
 	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
+	public boolean equals(final Object obj) {
+		if (this == obj) {
 			return true;
-		if (!super.equals(obj))
+		}
+		if (!super.equals(obj)) {
 			return false;
-		if (getClass() != obj.getClass())
+		}
+		if (getClass() != obj.getClass()) {
 			return false;
-		PatternString other = (PatternString) obj;
+		}
+		final PatternString other = (PatternString) obj;
 		if (matchString == null) {
-			if (other.matchString != null)
+			if (other.matchString != null) {
 				return false;
-		} else if (!matchString.equals(other.matchString))
+			}
+		} else if (!matchString.equals(other.matchString)) {
 			return false;
+		}
 		return true;
 	}
 

--- a/Packrat Parsing/src/structure/InputContext.java
+++ b/Packrat Parsing/src/structure/InputContext.java
@@ -84,7 +84,7 @@ public class InputContext {
 	 * @return true if the current position is at the end of the string (no active
 	 *         character to consume)
 	 */
-	public boolean atEnd() {
+	public boolean isAtEnd() {
 		return this.position == this.inputString.length();
 	}
 
@@ -102,7 +102,7 @@ public class InputContext {
 	 * @throws IllegalStateException if at the end of the input string
 	 */
 	public char currentChar() {
-		if (atEnd()) {
+		if (isAtEnd()) {
 			throw new IllegalStateException();
 		}
 		return this.inputString.charAt(position);
@@ -151,7 +151,7 @@ public class InputContext {
 	}
 
 	public boolean checkChar(final CharCheckable checker) {
-		if (atEnd()) {
+		if (isAtEnd()) {
 			return false;
 		}
 		return checker.check(currentDeriv().getChResult().getData().charAt(0));

--- a/Packrat Parsing/src/structure/InputContext.java
+++ b/Packrat Parsing/src/structure/InputContext.java
@@ -57,8 +57,8 @@ public class InputContext {
 			inputData[i] = new Derivation(input.charAt(i), i);
 		}
 
-		// For the last index, set it to null
-		inputData[input.length()] = null;
+		// For the last index, set it to an empty Derivation
+		inputData[input.length()] = new Derivation('\0', input.length());
 
 		// Start the print range off at the default
 		printRange = DEFAUT_PRINT_RANGE;

--- a/Packrat Parsing/src/structure/Result.java
+++ b/Packrat Parsing/src/structure/Result.java
@@ -20,6 +20,12 @@ public class Result {
 	/** The index at which this match ends, exclusive, 1-indexed. */
 	private int endIdx;
 
+	/**
+	 * Tracks whether this Result matches an alias, which should be skipped in the
+	 * printout tree.
+	 */
+	private boolean alias;
+
 	/** The left-recursion status of this Result. */
 	private LeftRecursionStatus lRStatus;
 
@@ -160,6 +166,20 @@ public class Result {
 	 */
 	public void setEndIdx(final int endIdx) {
 		this.endIdx = endIdx;
+	}
+
+	/**
+	 * @return the alias
+	 */
+	public boolean isAlias() {
+		return alias;
+	}
+
+	/**
+	 * @param alias the alias to set
+	 */
+	public void setAlias(final boolean alias) {
+		this.alias = alias;
 	}
 
 	/**

--- a/Packrat Parsing/src/structure/Result.java
+++ b/Packrat Parsing/src/structure/Result.java
@@ -183,12 +183,24 @@ public class Result {
 	}
 
 	/**
-	 * Adds a sub-match to this Result
+	 * Adds a sub-match to this Result. Transfers the child's information to this
+	 * parent Result (appends data, sets endIndex, etc.)
 	 * 
 	 * @param child
 	 */
 	public Result addChild(final Result child) {
+		// If this is the first child, set start index and empty data
+		if (children.isEmpty()) {
+			this.setData("");
+			this.setStartIdx(child.getStartIdx());
+		}
+		// Add the child to the children list
 		children.add(child);
+		// Append the child's data to our own
+		setData(this.getData() + child.getData());
+		// Set end index equal to child's end index
+		setEndIdx(child.getEndIdx());
+		// Return this object so that you can add multiple children in sequence
 		return this;
 	}
 

--- a/Packrat Parsing/test/patterns/definition/DefinitionExpressionTest.java
+++ b/Packrat Parsing/test/patterns/definition/DefinitionExpressionTest.java
@@ -1,0 +1,44 @@
+/**
+ * 
+ */
+package patterns.definition;
+
+import org.junit.Test;
+
+import patterns.general.Pattern;
+import util.PatternTestUtils;
+
+/**
+ * @author Melody Griesen
+ *
+ */
+public class DefinitionExpressionTest {
+
+	private static final Pattern PATTERN = new DefinitionExpression();
+
+	@Test
+	public void testMatchesNumber() {
+		// Matches number
+		PatternTestUtils.assertMatches(PATTERN, "1");
+		PatternTestUtils.assertMatches(PATTERN, "12345");
+		PatternTestUtils.assertMatches(PATTERN, "1230190123981");
+	}
+
+	@Test
+	public void testMatchesExpression() {
+		// Matches expressions
+		PatternTestUtils.assertMatches(PATTERN, "1+1");
+		PatternTestUtils.assertMatches(PATTERN, "598+29382");
+		PatternTestUtils.assertMatches(PATTERN, "1+2+34+567");
+	}
+
+	@Test
+	public void testRejects() {
+		PatternTestUtils.assertRejects(PATTERN, "");
+		PatternTestUtils.assertRejects(PATTERN, "a");
+		PatternTestUtils.assertRejects(PATTERN, " ");
+		PatternTestUtils.assertRejects(PATTERN, "-");
+		PatternTestUtils.assertRejects(PATTERN, "+5");
+	}
+
+}

--- a/Packrat Parsing/test/patterns/definition/DefinitionNumberTest.java
+++ b/Packrat Parsing/test/patterns/definition/DefinitionNumberTest.java
@@ -1,0 +1,42 @@
+/**
+ * 
+ */
+package patterns.definition;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import patterns.general.Pattern;
+import util.PatternTestUtils;
+
+/**
+ * @author Melody Griesen
+ *
+ */
+public class DefinitionNumberTest {
+
+	private static final Pattern PATTERN = new DefinitionNumber();
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@Before
+	public void setUp() throws Exception {
+	}
+
+	@Test
+	public void testValidMatches() {
+		PatternTestUtils.assertMatches(PATTERN, "1");
+		PatternTestUtils.assertMatches(PATTERN, "12345");
+		PatternTestUtils.assertMatches(PATTERN, "1230190123981");
+	}
+
+	@Test
+	public void testRejectsEmpty() {
+		PatternTestUtils.assertRejects(PATTERN, "");
+		PatternTestUtils.assertRejects(PATTERN, "a");
+		PatternTestUtils.assertRejects(PATTERN, " ");
+		PatternTestUtils.assertRejects(PATTERN, "-");
+	}
+
+}

--- a/Packrat Parsing/test/patterns/definition/SimpleExpressionTest.java
+++ b/Packrat Parsing/test/patterns/definition/SimpleExpressionTest.java
@@ -6,7 +6,7 @@ package patterns.definition;
 import org.junit.Test;
 
 import patterns.general.Pattern;
-import util.PatternMatchingTestUtils;
+import util.PatternTestUtils;
 
 /**
  * @author Melody Griesen
@@ -19,26 +19,26 @@ public class SimpleExpressionTest {
 	@Test
 	public void testMatchesNumber() {
 		// Matches number
-		PatternMatchingTestUtils.assertPatternMatches(PATTERN, "1");
-		PatternMatchingTestUtils.assertPatternMatches(PATTERN, "12345");
-		PatternMatchingTestUtils.assertPatternMatches(PATTERN, "1230190123981");
+		PatternTestUtils.assertMatches(PATTERN, "1");
+		PatternTestUtils.assertMatches(PATTERN, "12345");
+		PatternTestUtils.assertMatches(PATTERN, "1230190123981");
 	}
 
 	@Test
 	public void testMatchesExpression() {
 		// Matches expressions
-		PatternMatchingTestUtils.assertPatternMatches(PATTERN, "1+1");
-		PatternMatchingTestUtils.assertPatternMatches(PATTERN, "598+29382");
-		PatternMatchingTestUtils.assertPatternMatches(PATTERN, "1+2+34+567");
+		PatternTestUtils.assertMatches(PATTERN, "1+1");
+		PatternTestUtils.assertMatches(PATTERN, "598+29382");
+		PatternTestUtils.assertMatches(PATTERN, "1+2+34+567");
 	}
 
 	@Test
 	public void testRejects() {
-		PatternMatchingTestUtils.assertPatternRejects(PATTERN, "");
-		PatternMatchingTestUtils.assertPatternRejects(PATTERN, "a");
-		PatternMatchingTestUtils.assertPatternRejects(PATTERN, " ");
-		PatternMatchingTestUtils.assertPatternRejects(PATTERN, "-");
-		PatternMatchingTestUtils.assertPatternRejects(PATTERN, "+5");
+		PatternTestUtils.assertRejects(PATTERN, "");
+		PatternTestUtils.assertRejects(PATTERN, "a");
+		PatternTestUtils.assertRejects(PATTERN, " ");
+		PatternTestUtils.assertRejects(PATTERN, "-");
+		PatternTestUtils.assertRejects(PATTERN, "+5");
 	}
 
 }

--- a/Packrat Parsing/test/patterns/definition/SimpleNumberTest.java
+++ b/Packrat Parsing/test/patterns/definition/SimpleNumberTest.java
@@ -7,7 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import patterns.general.Pattern;
-import util.PatternMatchingTestUtils;
+import util.PatternTestUtils;
 
 /**
  * @author Melody Griesen
@@ -26,17 +26,17 @@ public class SimpleNumberTest {
 
 	@Test
 	public void testValidMatches() {
-		PatternMatchingTestUtils.assertPatternMatches(PATTERN, "1");
-		PatternMatchingTestUtils.assertPatternMatches(PATTERN, "12345");
-		PatternMatchingTestUtils.assertPatternMatches(PATTERN, "1230190123981");
+		PatternTestUtils.assertMatches(PATTERN, "1");
+		PatternTestUtils.assertMatches(PATTERN, "12345");
+		PatternTestUtils.assertMatches(PATTERN, "1230190123981");
 	}
 
 	@Test
 	public void testRejectsEmpty() {
-		PatternMatchingTestUtils.assertPatternRejects(PATTERN, "");
-		PatternMatchingTestUtils.assertPatternRejects(PATTERN, "a");
-		PatternMatchingTestUtils.assertPatternRejects(PATTERN, " ");
-		PatternMatchingTestUtils.assertPatternRejects(PATTERN, "-");
+		PatternTestUtils.assertRejects(PATTERN, "");
+		PatternTestUtils.assertRejects(PATTERN, "a");
+		PatternTestUtils.assertRejects(PATTERN, " ");
+		PatternTestUtils.assertRejects(PATTERN, "-");
 	}
 
 }

--- a/Packrat Parsing/test/patterns/general/PatternChoiceTest.java
+++ b/Packrat Parsing/test/patterns/general/PatternChoiceTest.java
@@ -1,0 +1,92 @@
+/**
+ * 
+ */
+package patterns.general;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import util.PatternTestUtils;
+
+/**
+ * @author Melody Griesen
+ *
+ */
+public class PatternChoiceTest {
+
+	Pattern pattern;
+
+	private static final Pattern one = new PatternString("one");
+	private static final Pattern two = new PatternDigit();
+	private static final Pattern three = new PatternString("three");
+
+	@Before
+	public void setup() {
+		pattern = new PatternChoice(one, two, three);
+	}
+
+	@Test
+	public void testAcceptChoice() {
+		// Ensure it can match any choice
+		PatternTestUtils.assertMatches(pattern, "one");
+		for (int i = 0; i < 10; i++) {
+			PatternTestUtils.assertMatches(pattern, String.valueOf(i));
+		}
+		PatternTestUtils.assertMatches(pattern, "three");
+	}
+
+	@Test
+	public void testAcceptEmpty() {
+		// Define PatternChoice with an extra, 4th ordered choice as epsilon (the empty
+		// string)
+		pattern = new PatternChoice(one, two, three, new PatternString(""));
+
+		// Ensure the first 3 patterns will be prioritized (they will be consumed if
+		// present)
+		PatternTestUtils.assertMatches(pattern, "one");
+		for (int i = 0; i < 10; i++) {
+			PatternTestUtils.assertMatches(pattern, String.valueOf(i));
+		}
+		PatternTestUtils.assertMatches(pattern, "three");
+
+		// Ensure it matches exactly the empty string
+		PatternTestUtils.assertMatches(pattern, "");
+
+		// Ensure it accepts prefixes to anything that doesn't exactly match
+		PatternTestUtils.assertMatchesPrefix(pattern, "only");
+		PatternTestUtils.assertMatchesPrefix(pattern, "different");
+		PatternTestUtils.assertMatchesPrefix(pattern, "-1982");
+	}
+
+	@Test
+	public void testAcceptNearPrefix() {
+		// Define PatternChoice with two choices, both starting with "on"
+		pattern = new PatternChoice(one, new PatternString("only"));
+
+		// Ensure both are matchable, and "on" is rejected
+		PatternTestUtils.assertMatches(pattern, "one");
+		PatternTestUtils.assertMatches(pattern, "only");
+		PatternTestUtils.assertRejects(pattern, "on");
+	}
+
+	@Test
+	public void testExactPrefix() {
+		// Define PatternChoice with two choices where the second is an extension of the
+		// first
+		pattern = new PatternChoice(new PatternString("on"), new PatternString("only"));
+
+		// Ensure first is matchable and second is not
+		PatternTestUtils.assertMatches(pattern, "on");
+		// No clean way to test for ensuring that it *only* matches a prefix
+		// TODO: Make a better way to test for explicit prefixes
+//		PatternTestUtils.assertRejects(pattern, "only");
+	}
+
+	@Test
+	public void testReject() {
+		PatternTestUtils.assertRejects(pattern, "");
+		PatternTestUtils.assertRejects(pattern, "on");
+		PatternTestUtils.assertRejects(pattern, "thre");
+	}
+
+}

--- a/Packrat Parsing/test/patterns/general/PatternDigitTest.java
+++ b/Packrat Parsing/test/patterns/general/PatternDigitTest.java
@@ -1,0 +1,30 @@
+package patterns.general;
+
+import org.junit.Test;
+
+import util.PatternTestUtils;
+
+public class PatternDigitTest {
+
+	private static final Pattern PATTERN = new PatternDigit();
+
+	@Test
+	public void testAccepts() {
+		for (int i = 0; i < 10; i++) {
+			PatternTestUtils.assertMatches(PATTERN, String.valueOf(i));
+		}
+	}
+
+	@Test
+	public void testRejects() {
+		PatternTestUtils.assertRejects(PATTERN, "");
+		PatternTestUtils.assertRejects(PATTERN, "a");
+		PatternTestUtils.assertRejects(PATTERN, "Z");
+		PatternTestUtils.assertRejects(PATTERN, "-");
+		PatternTestUtils.assertRejects(PATTERN, "_");
+		PatternTestUtils.assertRejects(PATTERN, "zero");
+		PatternTestUtils.assertRejects(PATTERN, "+");
+		PatternTestUtils.assertRejects(PATTERN, "!");
+	}
+
+}

--- a/Packrat Parsing/test/patterns/general/PatternRepetitionTest.java
+++ b/Packrat Parsing/test/patterns/general/PatternRepetitionTest.java
@@ -1,0 +1,88 @@
+/**
+ * 
+ */
+package patterns.general;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import util.PatternTestUtils;
+
+/**
+ * @author Melody Griesen
+ *
+ */
+public class PatternRepetitionTest {
+
+	Pattern pattern;
+
+	private static final Pattern digit = new PatternDigit();
+
+	@Test
+	public void testData() {
+
+		// Test improper calls
+		Assert.assertThrows(IllegalArgumentException.class, () -> {
+			new PatternRepetition(null, 0, 1);
+		});
+		Assert.assertThrows(IllegalArgumentException.class, () -> {
+			new PatternRepetition(digit, -1, 1);
+		});
+		Assert.assertThrows(IllegalArgumentException.class, () -> {
+			new PatternRepetition(digit, 0, -2);
+		});
+
+	}
+
+	@Test
+	public void testStar() {
+		// Pattern allows 0-infinity matches
+		pattern = new PatternRepetition(digit, 0, -1);
+
+		PatternTestUtils.assertMatches(pattern, "");
+		PatternTestUtils.assertMatches(pattern, "1");
+		PatternTestUtils.assertMatches(pattern, "12");
+		PatternTestUtils.assertMatches(pattern, "123");
+		PatternTestUtils.assertMatches(pattern, "1234");
+	}
+
+	@Test
+	public void testPlus() {
+		// Pattern allows 1-infinity matches
+		pattern = new PatternRepetition(digit, 1, -1);
+
+		PatternTestUtils.assertRejects(pattern, "");
+		PatternTestUtils.assertMatches(pattern, "1");
+		PatternTestUtils.assertMatches(pattern, "12");
+		PatternTestUtils.assertMatches(pattern, "123");
+		PatternTestUtils.assertMatches(pattern, "1234");
+
+	}
+
+	@Test
+	public void testRange() {
+		// Pattern allows 1-3 matches
+		pattern = new PatternRepetition(digit, 1, 3);
+
+		PatternTestUtils.assertRejects(pattern, "");
+		PatternTestUtils.assertMatches(pattern, "1");
+		PatternTestUtils.assertMatches(pattern, "12");
+		PatternTestUtils.assertMatches(pattern, "123");
+		PatternTestUtils.assertMatchesPrefix(pattern, "1234");
+
+	}
+
+	@Test
+	public void testExact() {
+		// Pattern requires exactly 3 repetitions
+		pattern = new PatternRepetition(digit, 3, 3);
+
+		PatternTestUtils.assertRejects(pattern, "");
+		PatternTestUtils.assertRejects(pattern, "1");
+		PatternTestUtils.assertRejects(pattern, "12");
+		PatternTestUtils.assertMatches(pattern, "123");
+		PatternTestUtils.assertMatchesPrefix(pattern, "1234");
+
+	}
+
+}

--- a/Packrat Parsing/test/patterns/general/PatternSequenceTest.java
+++ b/Packrat Parsing/test/patterns/general/PatternSequenceTest.java
@@ -1,0 +1,44 @@
+/**
+ * 
+ */
+package patterns.general;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import util.PatternTestUtils;
+
+/**
+ * @author Melody Griesen
+ *
+ */
+public class PatternSequenceTest {
+
+	Pattern pattern;
+
+	private static final Pattern one = new PatternString("one");
+	private static final Pattern two = new PatternDigit();
+	private static final Pattern three = new PatternString("three");
+
+	@Before
+	public void setup() {
+		pattern = new PatternSequence(one, two, three);
+	}
+
+	@Test
+	public void testAccepts() {
+		PatternTestUtils.assertMatches(pattern, "one2three");
+		PatternTestUtils.assertMatches(pattern, "one5three");
+		PatternTestUtils.assertMatches(pattern, "one0three");
+	}
+
+	@Test
+	public void testRejects() {
+		PatternTestUtils.assertRejects(pattern, "onetwothree");
+		PatternTestUtils.assertRejects(pattern, "one5thre");
+		PatternTestUtils.assertRejects(pattern, "2three");
+		PatternTestUtils.assertRejects(pattern, "onethree");
+		PatternTestUtils.assertRejects(pattern, "one2");
+	}
+
+}

--- a/Packrat Parsing/test/patterns/general/PatternStringTest.java
+++ b/Packrat Parsing/test/patterns/general/PatternStringTest.java
@@ -1,0 +1,54 @@
+/**
+ * 
+ */
+package patterns.general;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import util.PatternTestUtils;
+
+/**
+ * @author Melody Griesen
+ *
+ */
+public class PatternStringTest {
+
+	private static final String TARGET_STRING = "Hello, World!";
+
+	private Pattern pattern;
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@Before
+	public void setUp() throws Exception {
+		// Sets up each test to default to a pattern that matches the target string
+		// given above
+		pattern = new PatternString(TARGET_STRING);
+	}
+
+	@Test
+	public void testAcceptRegular() {
+		PatternTestUtils.assertMatches(pattern, TARGET_STRING);
+		PatternTestUtils.assertMatchesPrefix(pattern, TARGET_STRING);
+		PatternTestUtils.assertMatchesPrefix(pattern, TARGET_STRING + "asdf");
+	}
+
+	@Test
+	public void testAcceptEmpty() {
+		// Re-define pattern to match empty string
+		pattern = new PatternString("");
+
+		PatternTestUtils.assertMatches(pattern, "");
+		PatternTestUtils.assertMatchesPrefix(pattern, TARGET_STRING);
+	}
+
+	@Test
+	public void testRejects() {
+		PatternTestUtils.assertRejects(pattern, "");
+		PatternTestUtils.assertRejects(pattern, "asdf");
+		PatternTestUtils.assertRejects(pattern, TARGET_STRING.substring(0, TARGET_STRING.length() - 1));
+	}
+
+}

--- a/Packrat Parsing/test/util/PatternMatchingTestUtils.java
+++ b/Packrat Parsing/test/util/PatternMatchingTestUtils.java
@@ -138,21 +138,25 @@ public class PatternMatchingTestUtils {
 
 		// Expect success or failure
 		if (expectedSuccess) {
-			Assert.assertTrue(inputString + "Match should succeed", matcher.r.isSuccess());
+			// Ensure positive match
+			Assert.assertTrue(inputString + "Match should succeed.", matcher.r.isSuccess());
 			// Ensure the match is a prefix of the original string
-			Assert.assertTrue(inputString + "Match should be less or equal to input in length",
+			Assert.assertTrue(inputString + "Match should be less or equal to input in length.",
 					matcher.r.getData().length() <= s.length());
-			Assert.assertEquals(inputString + "Match should be a prefix of input",
+			Assert.assertEquals(inputString + "Match should be a prefix of input.",
 					s.substring(0, matcher.r.getData().length()), matcher.r.getData());
+			// Ensure match's type matches pattern's type
+			Assert.assertEquals(inputString + "Match Result's type should match Pattern's type.", p.getType(),
+					matcher.r.getType());
 		} else {
-			Assert.assertFalse(inputString + "Match should not succeed", matcher.r.isSuccess());
+			Assert.assertFalse(inputString + "Match should not succeed.", matcher.r.isSuccess());
 		}
 
 		// If we need a full match, ensure the context is at the end and the strings
 		// match exactly
 		if (requireFullMatch) {
-			Assert.assertTrue(inputString + "Input string should be exhausted", matcher.context.atEnd());
-			Assert.assertEquals(inputString + "Result data should match input", s, matcher.r.getData());
+			Assert.assertTrue(inputString + "Input string should be exhausted.", matcher.context.atEnd());
+			Assert.assertEquals(inputString + "Result data should match input.", s, matcher.r.getData());
 		}
 	}
 

--- a/Packrat Parsing/test/util/PatternTestUtils.java
+++ b/Packrat Parsing/test/util/PatternTestUtils.java
@@ -115,7 +115,7 @@ public class PatternTestUtils {
 		}
 
 		// If it's stuck in an infinite loop, then fail by that reason.
-		if (matcher.isAlive()) {
+		if (matcher.isAlive() && !matcher.workDone) {
 			matcher.stop();
 			Assert.fail(inputString + "Test timed out after " + TIMEOUT + " miliseconds.");
 		}
@@ -182,6 +182,8 @@ public class PatternTestUtils {
 		/** Stores any Exceptions that caused this matching thread's death. */
 		RuntimeException causeOfDeath;
 
+		boolean workDone = false;
+
 		/**
 		 * Constructs this matcher thread by providing the input string and pattern to
 		 * match.
@@ -205,6 +207,7 @@ public class PatternTestUtils {
 		public void run() {
 			try {
 				r = p.lazyMatch(context);
+				workDone = true;
 				synchronized (this) {
 					this.notifyAll();
 				}

--- a/Packrat Parsing/test/util/PatternTestUtils.java
+++ b/Packrat Parsing/test/util/PatternTestUtils.java
@@ -15,7 +15,7 @@ import structure.Result;
  * @author Melody
  *
  */
-public class PatternMatchingTestUtils {
+public class PatternTestUtils {
 
 	/**
 	 * Time (in miliseconds) after which the test runner will kill any matching
@@ -30,7 +30,7 @@ public class PatternMatchingTestUtils {
 	 * @param p pattern to attempt to match
 	 * @param s input string to use
 	 */
-	public static void assertPatternMatchesPrefix(final Pattern p, final String s) {
+	public static void assertMatchesPrefix(final Pattern p, final String s) {
 		assertPatternAgainstExpected(p, s, true, false);
 	}
 
@@ -41,7 +41,7 @@ public class PatternMatchingTestUtils {
 	 * @param p pattern to attempt to match
 	 * @param s input string to use
 	 */
-	public static void assertPatternMatches(final Pattern p, final String s) {
+	public static void assertMatches(final Pattern p, final String s) {
 		assertPatternAgainstExpected(p, s, true, true);
 	}
 
@@ -51,7 +51,7 @@ public class PatternMatchingTestUtils {
 	 * @param p pattern to attempt to match
 	 * @param s input string to use
 	 */
-	public static void assertPatternRejects(final Pattern p, final String s) {
+	public static void assertRejects(final Pattern p, final String s) {
 		assertPatternAgainstExpected(p, s, false, false);
 	}
 
@@ -155,7 +155,7 @@ public class PatternMatchingTestUtils {
 		// If we need a full match, ensure the context is at the end and the strings
 		// match exactly
 		if (requireFullMatch) {
-			Assert.assertTrue(inputString + "Input string should be exhausted.", matcher.context.atEnd());
+			Assert.assertTrue(inputString + "Input string should be exhausted.", matcher.context.isAtEnd());
 			Assert.assertEquals(inputString + "Result data should match input.", s, matcher.r.getData());
 		}
 	}


### PR DESCRIPTION
I'm very happy with how the design and implementation work for this solution, it's fairly elegant. Fixes #6 and #9 

Patterns must always provide a method `String getType()` indicating their type. This can return null, in which case the pattern will be skipped over in memoization and the Result it generates will not print in the default (concise) Result tree. Results can also acquire this functionality by setting themselves as aliases, allowing them to have a valid `type` but still possess the benefits mentioned above.

This is a large step towards making this library very easy to work with for prototyping. Future iterations will likely expand the test suite, cut out unneeded components of Pattern and Derivation, aim to implement some of the designs present in the PEXL matching software such as instruction level matching and static left-recursive pattern marking, and aim to incorporate some of the solutions for advanced problems like indirect left-recursion and left-recursion with right-recursion outlined by Warth and Tratt, respectively.