### PR TITLE
Test Result, minor refactorings and bugfixes

### DIFF
--- a/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/Pattern.java
+++ b/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/Pattern.java
@@ -312,6 +312,7 @@ public abstract class Pattern {
 			// Set m to a failure Result with a left recursion status of POSSIBLE to
 			// indicate we suspect but don't know that the Pattern might be left recursive
 			m = Result.FAIL(initialPosition);
+			m.setLRStatus(LeftRecursionStatus.POSSIBLE);
 
 			// MEMO(R,P) = m
 			// Set the memoized answer for applying this rule at this position to be m, the

--- a/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/component/PatternChoice.java
+++ b/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/component/PatternChoice.java
@@ -76,7 +76,7 @@ public class PatternChoice extends PatternComponent {
 	@Override
 	protected Result match(final InputContext context) {
 		// Track the initial starting position
-		final Result choice = new Result("", context.getPosition());
+		final Result choice = new Result(context.getPosition());
 
 		// Run through the list of patterns to match
 		// Keep track of the previous pattern's result
@@ -187,7 +187,7 @@ public class PatternChoice extends PatternComponent {
 	 */
 	@Override
 	protected Iterator<Pattern> getPossibleLeftmostComponents() {
-		return new ArrayList<Pattern>(patterns).iterator();
+		return new ArrayList<>(patterns).iterator();
 	}
 
 	/**

--- a/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/component/PatternChoice.java
+++ b/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/component/PatternChoice.java
@@ -76,7 +76,7 @@ public class PatternChoice extends PatternComponent {
 	@Override
 	protected Result match(final InputContext context) {
 		// Track the initial starting position
-		final Result choice = new Result(true, "", context.getPosition());
+		final Result choice = new Result("", context.getPosition());
 
 		// Run through the list of patterns to match
 		// Keep track of the previous pattern's result

--- a/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/component/PatternDigit.java
+++ b/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/component/PatternDigit.java
@@ -34,7 +34,7 @@ public class PatternDigit extends PatternComponent {
 			final int startPos = context.getPosition();
 			context.addHistory(new CharacterAcceptEvent(context, startPos));
 			context.advance();
-			return new Result(true, ch, startPos);
+			return new Result(ch, startPos);
 		} else {
 			// Not a digit. Failure
 			return Result.FAIL(context.getPosition());

--- a/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/component/PatternPredicate.java
+++ b/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/component/PatternPredicate.java
@@ -48,7 +48,7 @@ public class PatternPredicate extends PatternComponent {
 	protected Result match(final InputContext context) {
 
 		// Create a Result for the predication
-		final Result pred = new Result("", context.getPosition());
+		final Result pred = new Result(context.getPosition());
 
 		// Save the start position
 		final int startPos = context.getPosition();

--- a/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/component/PatternPredicate.java
+++ b/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/component/PatternPredicate.java
@@ -48,7 +48,7 @@ public class PatternPredicate extends PatternComponent {
 	protected Result match(final InputContext context) {
 
 		// Create a Result for the predication
-		final Result pred = new Result(true, "", context.getPosition());
+		final Result pred = new Result("", context.getPosition());
 
 		// Save the start position
 		final int startPos = context.getPosition();

--- a/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/component/PatternRepetition.java
+++ b/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/component/PatternRepetition.java
@@ -58,7 +58,7 @@ public class PatternRepetition extends PatternComponent {
 	@Override
 	protected Result match(final InputContext context) {
 		// Create an overall result to track starting position
-		final Result repetition = new Result("", context.getPosition());
+		final Result repetition = new Result(context.getPosition());
 		// Track the number of successful iterations
 		int matches = 0;
 

--- a/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/component/PatternRepetition.java
+++ b/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/component/PatternRepetition.java
@@ -58,7 +58,7 @@ public class PatternRepetition extends PatternComponent {
 	@Override
 	protected Result match(final InputContext context) {
 		// Create an overall result to track starting position
-		final Result repetition = new Result(true, "", context.getPosition());
+		final Result repetition = new Result("", context.getPosition());
 		// Track the number of successful iterations
 		int matches = 0;
 

--- a/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/component/PatternSequence.java
+++ b/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/component/PatternSequence.java
@@ -77,7 +77,7 @@ public class PatternSequence extends PatternComponent {
 	protected Result match(final InputContext context) {
 		// Run through the list of patterns to match
 		// Keep track of the previous pattern's result
-		final Result sequence = new Result(true, "", context.getPosition());
+		final Result sequence = new Result("", context.getPosition());
 		Result result;
 		// Sequence index for event reporting
 		int sequenceIdx = 0;

--- a/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/component/PatternSequence.java
+++ b/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/component/PatternSequence.java
@@ -77,7 +77,7 @@ public class PatternSequence extends PatternComponent {
 	protected Result match(final InputContext context) {
 		// Run through the list of patterns to match
 		// Keep track of the previous pattern's result
-		final Result sequence = new Result("", context.getPosition());
+		final Result sequence = new Result(context.getPosition());
 		Result result;
 		// Sequence index for event reporting
 		int sequenceIdx = 0;
@@ -185,36 +185,36 @@ public class PatternSequence extends PatternComponent {
 	 */
 	@Override
 	protected Iterator<Pattern> getPossibleLeftmostComponents() {
-		
+
 		// Return a custom Iterator over the patterns in this sequence.
 		// Elements are returned from next() if all leftward elements are nullable.
-		return new Iterator<Pattern>() {
-			
+		return new Iterator<>() {
+
 			/** List to return elements from */
 			List<Pattern> sequenceComponents = patterns;
-			
+
 			/** Current position in the list */
 			int idx = 0;
-			
+
 			/**
-			 * The next element is returnable if it's at the front of the list, or
-			 * the element to its left is nullable
+			 * The next element is returnable if it's at the front of the list, or the
+			 * element to its left is nullable
 			 * 
-			 * @return true if the iterator is at the front of the list, or if the
-			 * previous element is nullable.
+			 * @return true if the iterator is at the front of the list, or if the previous
+			 *         element is nullable.
 			 */
 			@Override
 			public boolean hasNext() {
-				return idx == 0 || patterns.get(idx - 1).isNullable();
+				return (idx == 0) || patterns.get(idx - 1).isNullable();
 			}
-			
+
 			/**
-			 * If there is another element to retrieve, returns it and advances the
-			 * iterator one position.
+			 * If there is another element to retrieve, returns it and advances the iterator
+			 * one position.
 			 * 
 			 * @return the next possibly left-recursive element in the list
-			 * @throws NoSuchElementException if there are no more left-recursive
-			 * elements in the list
+			 * @throws NoSuchElementException if there are no more left-recursive elements
+			 *                                in the list
 			 */
 			@Override
 			public Pattern next() {
@@ -222,7 +222,7 @@ public class PatternSequence extends PatternComponent {
 				if (!hasNext()) {
 					throw new NoSuchElementException("No more left-recursive elements in sequence");
 				}
-				
+
 				// Return the next element and increment the position
 				return sequenceComponents.get(idx++);
 			}

--- a/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/component/PatternString.java
+++ b/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/component/PatternString.java
@@ -39,7 +39,7 @@ public class PatternString extends PatternComponent {
 		final int initialPosition = context.getPosition();
 
 		// Use iterative solution
-		final Result match = new Result("", initialPosition);
+		final Result match = new Result(initialPosition);
 
 		// Loop for each character of the target string
 		for (final char c : matchString.toCharArray()) {

--- a/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/component/PatternString.java
+++ b/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/component/PatternString.java
@@ -39,7 +39,7 @@ public class PatternString extends PatternComponent {
 		final int initialPosition = context.getPosition();
 
 		// Use iterative solution
-		final Result match = new Result(true, "", initialPosition);
+		final Result match = new Result("", initialPosition);
 
 		// Loop for each character of the target string
 		for (final char c : matchString.toCharArray()) {

--- a/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/definition/SimpleExpression.java
+++ b/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/definition/SimpleExpression.java
@@ -42,7 +42,7 @@ public class SimpleExpression extends Pattern {
 	private Result tryFullExpression(final InputContext context) {
 
 		// Create the possible Result found by matching this Expression
-		final Result expression = new Result("", context.getPosition());
+		final Result expression = new Result(context.getPosition());
 		expression.setType("Expression");
 
 		// Create a placeholder for the Results returned by each sub-match

--- a/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/definition/SimpleExpression.java
+++ b/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/definition/SimpleExpression.java
@@ -33,7 +33,7 @@ public class SimpleExpression extends Pattern {
 			return result;
 		}
 
-		final Result expression = new Result(true, result.getData(), result.getStartIdx());
+		final Result expression = new Result(result.getStartIdx());
 		expression.setType("Expression");
 		expression.addChild(result);
 		return expression;
@@ -42,7 +42,7 @@ public class SimpleExpression extends Pattern {
 	private Result tryFullExpression(final InputContext context) {
 
 		// Create the possible Result found by matching this Expression
-		final Result expression = new Result(true, "", context.getPosition());
+		final Result expression = new Result("", context.getPosition());
 		expression.setType("Expression");
 
 		// Create a placeholder for the Results returned by each sub-match
@@ -84,7 +84,7 @@ public class SimpleExpression extends Pattern {
 		if (!context.isAtEnd() && (context.currentChar() == '+')) {
 			context.addHistory(new CharacterAcceptEvent(context, context.getPosition()));
 			context.advance();
-			return new Result(true, '+', context.getPosition() - 1);
+			return new Result('+', context.getPosition() - 1);
 		} else {
 			return Result.FAIL(context.getPosition());
 		}

--- a/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/definition/SimpleNumber.java
+++ b/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/definition/SimpleNumber.java
@@ -17,7 +17,7 @@ public class SimpleNumber extends Pattern {
 			return Result.FAIL(context.getPosition());
 		}
 
-		final Result priorResult = new Result(true, context.currentChar(), context.getPosition());
+		final Result priorResult = new Result(context.currentChar(), context.getPosition());
 //		priorResult.setType("Number");
 
 		char match = context.next();

--- a/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/structure/Result.java
+++ b/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/structure/Result.java
@@ -43,7 +43,7 @@ public class Result {
 	 * @return a Result representing a failed match.
 	 */
 	public static final Result FAIL(final int idx) {
-		final Result fail = new Result("", idx);
+		final Result fail = new Result(idx);
 		fail.setAlias(false);
 		fail.setSuccess(false);
 		fail.setLRStatus(LeftRecursionStatus.IMPOSSIBLE);

--- a/PEG Direct Left-Recursion Prototype/test/edu/ncsu/csc499/peg_lr/structure/ResultTest.java
+++ b/PEG Direct Left-Recursion Prototype/test/edu/ncsu/csc499/peg_lr/structure/ResultTest.java
@@ -1,74 +1,231 @@
 package edu.ncsu.csc499.peg_lr.structure;
 
-import static org.junit.Assert.fail;
-
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import edu.ncsu.csc499.peg_lr.structure.Result.LeftRecursionStatus;
+
 public class ResultTest {
+
+	/** Test object */
+	private Result result;
 
 	@Before
 	public void setUp() throws Exception {
+		result = new Result("asdf", 1);
 	}
 
 	@Test
 	public void testFAIL() {
-		fail("Not yet implemented");
+		// The failed Result should:
+		final Result FAIL = Result.FAIL(3);
+
+		// not be successful
+		Assert.assertFalse(FAIL.isSuccess());
+
+		// have no Type
+		Assert.assertEquals(null, FAIL.getType());
+		// not be an alias
+		Assert.assertEquals(false, FAIL.isAlias());
+		// be hidden
+		Assert.assertTrue(FAIL.isHidden());
+
+		// hold an empty string of data
+		Assert.assertEquals("", FAIL.getData());
+
+		// go from idx to idx
+		Assert.assertEquals(3, FAIL.getStartIdx());
+		Assert.assertEquals(3, FAIL.getEndIdx());
+
+		// not be left-recursive
+		Assert.assertEquals(LeftRecursionStatus.IMPOSSIBLE, FAIL.getLRStatus());
+
+		// be unique from another call to FAIL:
+		Assert.assertNotSame(Result.FAIL(3), FAIL);
+
 	}
 
 	@Test
-	public void testResultBooleanTDerivation() {
-		fail("Not yet implemented");
+	public void testConstructorIndex() {
+		// Construct result with no data at idx 1
+		result = new Result(1);
+
+		// Ensure desired properties
+		Assert.assertTrue(result.isSuccess());
+		Assert.assertEquals(1, result.getStartIdx());
+		Assert.assertEquals(1, result.getEndIdx());
+		Assert.assertEquals("", result.getData());
+		Assert.assertTrue(result.isHidden());
+		Assert.assertFalse(result.isAlias());
+		Assert.assertNull(result.getType());
+		Assert.assertEquals(LeftRecursionStatus.POSSIBLE, result.getLRStatus());
 	}
 
 	@Test
-	public void testResultBooleanTDerivationLeftRecursionStatus() {
-		fail("Not yet implemented");
+	public void testConstructorSingleCharacter() {
+		// Construct result with single character 'a' at idx 1
+		result = new Result('a', 1);
+
+		// Ensure desired properties
+		Assert.assertTrue(result.isSuccess());
+		Assert.assertEquals(1, result.getStartIdx());
+		Assert.assertEquals(2, result.getEndIdx());
+		Assert.assertEquals("a", result.getData());
+		Assert.assertTrue(result.isHidden());
+		Assert.assertFalse(result.isAlias());
+		Assert.assertNull(result.getType());
+		Assert.assertEquals(LeftRecursionStatus.POSSIBLE, result.getLRStatus());
 	}
 
 	@Test
-	public void testIsSuccess() {
-		fail("Not yet implemented");
+	public void testConstructorData() {
+		// Construct result with data "asdf" at idx 1
+		result = new Result("asdf", 1);
+
+		// Ensure desired properties
+		Assert.assertTrue(result.isSuccess());
+		Assert.assertEquals(1, result.getStartIdx());
+		Assert.assertEquals(5, result.getEndIdx());
+		Assert.assertEquals("asdf", result.getData());
+		Assert.assertTrue(result.isHidden());
+		Assert.assertFalse(result.isAlias());
+		Assert.assertNull(result.getType());
+		Assert.assertEquals(LeftRecursionStatus.POSSIBLE, result.getLRStatus());
 	}
 
 	@Test
-	public void testSetSuccess() {
-		fail("Not yet implemented");
+	public void testConstructorFull() {
+		// Construct successful result with data "asdf" at idx 1
+		result = new Result(true, "asdf", 1, LeftRecursionStatus.IMPOSSIBLE);
+
+		// Ensure desired properties
+		Assert.assertTrue(result.isSuccess());
+		Assert.assertEquals(1, result.getStartIdx());
+		Assert.assertEquals(5, result.getEndIdx());
+		Assert.assertEquals("asdf", result.getData());
+		Assert.assertTrue(result.isHidden());
+		Assert.assertFalse(result.isAlias());
+		Assert.assertNull(result.getType());
+		Assert.assertEquals(LeftRecursionStatus.IMPOSSIBLE, result.getLRStatus());
+
+		// Construct failed result with data "" at idx 1
+		result = new Result(false, "", 1, LeftRecursionStatus.IMPOSSIBLE);
+
+		// Ensure desired properties
+		Assert.assertFalse(result.isSuccess());
+		Assert.assertEquals(1, result.getStartIdx());
+		Assert.assertEquals(1, result.getEndIdx());
+		Assert.assertEquals("", result.getData());
+		Assert.assertTrue(result.isHidden());
+		Assert.assertFalse(result.isAlias());
+		Assert.assertNull(result.getType());
+		Assert.assertEquals(LeftRecursionStatus.IMPOSSIBLE, result.getLRStatus());
 	}
 
 	@Test
-	public void testGetValue() {
-		fail("Not yet implemented");
+	public void testHidden() {
+		// Default result is null-type not-alias: hidden
+		Assert.assertNull(result.getType());
+		Assert.assertFalse(result.isAlias());
+		Assert.assertTrue(result.isHidden());
+
+		// Set to true alias
+		result.setAlias(true);
+
+		// Result is now null-type alias: hidden
+		Assert.assertNull(result.getType());
+		Assert.assertTrue(result.isAlias());
+		Assert.assertTrue(result.isHidden());
+
+		// Set type to something valid
+		result.setType("type");
+
+		// Result is now non-null-type alias: hidden
+		Assert.assertNotNull(result.getType());
+		Assert.assertTrue(result.isAlias());
+		Assert.assertTrue(result.isHidden());
+
+		// Set alias to false
+		result.setAlias(false);
+
+		// Result is now non-null-type not-alias: not hidden
+		Assert.assertNotNull(result.getType());
+		Assert.assertFalse(result.isAlias());
+		Assert.assertFalse(result.isHidden());
+
+		// Restore initial state by setting type to null
+		result.setType(null);
+		// Default result is null-type not-alias: hidden
+		Assert.assertNull(result.getType());
+		Assert.assertFalse(result.isAlias());
+		Assert.assertTrue(result.isHidden());
 	}
 
 	@Test
-	public void testSetValue() {
-		fail("Not yet implemented");
+	public void testAddChar() {
+		// Initial result is "asdf" idx 1-5
+
+		// Add another character 'g'
+		result.addChar('g');
+
+		// Test updates
+		Assert.assertEquals("asdfg", result.getData());
+		Assert.assertEquals(6, result.getEndIdx());
+
+		// Test start stayed the same
+		Assert.assertEquals(1, result.getStartIdx());
 	}
 
 	@Test
-	public void testGetDerivation() {
-		fail("Not yet implemented");
-	}
+	public void testAddChild() {
+		// Start off with empty string
+		result = new Result(1);
 
-	@Test
-	public void testSetDerivation() {
-		fail("Not yet implemented");
-	}
+		// Add a child that holds "as". Parent result should be returned.
+		Assert.assertSame(result, result.addChild(new Result("as", 1)));
 
-	@Test
-	public void testGetLRStatus() {
-		fail("Not yet implemented");
-	}
+		// Parent result should now hold child's info
+		Assert.assertEquals(1, result.getStartIdx());
+		Assert.assertEquals("as", result.getData());
+		Assert.assertEquals(3, result.getEndIdx());
 
-	@Test
-	public void testSetLRStatus() {
-		fail("Not yet implemented");
+		// Add a second child that holds "df". Parent result should be returned.
+		Assert.assertSame(result, result.addChild(new Result("df", 3)));
+
+		// Parent result should now hold child's info
+		Assert.assertEquals(1, result.getStartIdx());
+		Assert.assertEquals("asdf", result.getData());
+		Assert.assertEquals(5, result.getEndIdx());
+
+		// Invalid cases
+
+		// Shouldn't be able to add a child with an end index that doesn't match the
+		// parent's current end index
+
+		// Direct test
+		Assert.assertThrows(IllegalArgumentException.class, () -> {
+			result.addChild(new Result("j", 7));
+		});
+
+		// After adding a character
+		result.addChar('g');
+		Assert.assertThrows(IllegalArgumentException.class, () -> {
+			result.addChild(new Result("j", 7));
+		});
+
 	}
 
 	@Test
 	public void testToString() {
-		fail("Not yet implemented");
+		// Ensure that string contains the data we expect it to show
+		final String toString = result.toString();
+
+		Assert.assertTrue(toString.contains(result.getData()));
+		Assert.assertTrue(toString.contains("" + result.getType()));
+		Assert.assertTrue(toString.contains("" + result.getStartIdx()));
+		Assert.assertTrue(toString.contains("" + result.getEndIdx()));
+		Assert.assertTrue(toString.contains(result.getLRStatus().toString()));
 	}
 
 }


### PR DESCRIPTION
Fixes #36 and makes minor improvements:
 - Result constructors have less boilerplate and more options
 - addChild() now checks indices to make sure you're adding a child w/ the right position
 - Full coverage and passing tests for all Result methods except for printResultTree()