### PR TITLE
Refactor main lazy matching to use static LR detection instead of dynamic

### DIFF
--- a/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/event/control/MemoryEvent.java
+++ b/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/event/control/MemoryEvent.java
@@ -23,7 +23,9 @@ public class MemoryEvent extends ControlEvent {
 		/** Memory was checked. */
 		CHECK("Check"),
 		/** Memory was saved. */
-		SAVE("Save");
+		SAVE("Save"),
+		/** Memory was cleared. */
+		CLEAR("Clear");
 
 		/** Stores a display-friendly name for this enum. */
 		private String displayName;

--- a/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/Pattern.java
+++ b/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/Pattern.java
@@ -275,171 +275,164 @@ public abstract class Pattern {
 	 */
 	public final Result lazyMatch(final InputContext context) {
 
-		// If this pattern has no Type or is an alias, delegate immediately to match()
-		if (this.isHidden()) {
+		// If this pattern is hidden or not left-recursive, delegate immediately to
+		// match()
+		if (this.isHidden() | !this.isLeftRecursive()) {
 
 			// Skip left-recursion and memoization
 			return this.matchAndName(context);
 		}
+		// Otherwise, it's left-recursive.
+		else {
+			// Begin the main LR algorithm
 
-		// Begin the full meta-match
-		// Log it in the context
-		context.addHistory(new MetaMatchEvent(context, this, context.getPosition(), MetaMatchEventType.BEGIN_PREP));
+			// Log it in the context
+			context.addHistory(new MetaMatchEvent(context, this, context.getPosition(), MetaMatchEventType.BEGIN_PREP));
 
-		// let m = MEMO(R,P)
-		// Let m hold the "known" result of applying this Rule at this Position
-		// Let m hold the "known" result of applying this Pattern at this Derivation
-		Result m = context.resultFor(this);
+			// let m = MEMO(R,P)
+			// Let m hold the "known" result of applying this Rule at this Position
+			// Let m hold the "known" result of applying this Pattern at this Derivation
+			Result m = context.resultFor(this);
 
-		// if m = NIL
-		// If the "known" result does not yet exist
-		if (m == null) {
+			// if m = NIL
+			// If the "known" result does not yet exist
+			if (m == null) {
 
-			// Log that we're going to have to manually run a match
-			context.addHistory(new MetaMatchEvent(context, this, context.getPosition(), MetaMatchEventType.RUN_MATCH));
+				// Log that we're going to have to manually run a match
+				context.addHistory(
+						new MetaMatchEvent(context, this, context.getPosition(), MetaMatchEventType.RUN_MATCH));
 
-			// Save the initial position before matching in case we need to grow the match
-			final int initialPosition = context.getPosition();
+				// Save the initial position before matching in case we need to grow the match
+				final int initialPosition = context.getPosition();
 
-			// let lr = new LR(FALSE)
-			// Create a new LeftRecursion tracker that says this rule is suspected but not
-			// confirmed to be left recursive
-			// Create the subsequent Result with a LeftRecursionStatus of POSSIBLE
+				// let lr = new LR(FALSE)
+				// Create a new LeftRecursion tracker that says this rule is suspected but not
+				// confirmed to be left recursive
+				// Create the subsequent Result with a LeftRecursionStatus of POSSIBLE
 
-			// m = new MemoEntry(lr,P)
-			// Set m to a failure entry that points us back to the same starting position
-			// and indicates that this rule might be left recursive
-			// Set m to a failure Result with a left recursion status of POSSIBLE to
-			// indicate we suspect but don't know that the Pattern might be left recursive
-			m = Result.FAIL(initialPosition);
-			m.setLRStatus(LeftRecursionStatus.POSSIBLE);
+				// m = new MemoEntry(lr,P)
+				// Set m to a failure entry that points us back to the same starting position
+				// and indicates that this rule might be left recursive
+				// Set m to a failure Result with a left recursion status of POSSIBLE to
+				// indicate we suspect but don't know that the Pattern might be left recursive
+				m = Result.FAIL(initialPosition);
+				m.setLRStatus(LeftRecursionStatus.POSSIBLE);
 
-			// MEMO(R,P) = m
-			// Set the memoized answer for applying this rule at this position to be m, the
-			// failure memo
-			// Set the Result for applying this Pattern on this Derivation to be m, the
-			// failure Result
-			context.setResultFor(this, m);
+				// MEMO(R,P) = m
+				// Set the memoized answer for applying this rule at this position to be m, the
+				// failure memo
+				// Set the Result for applying this Pattern on this Derivation to be m, the
+				// failure Result
+				context.setResultFor(this, m);
 
-			// let ans = EVAL(R.body)
-			// Evaluate the Rule at this position, saving the answer in the field "ans"
-			// Attempt to match the Pattern on this Derivation, saving the Result in the
-			// field "ans"
-			final Result ans = matchAndName(context);
-			ans.setType(getType());
-			ans.setAlias(isAlias());
+				// let ans = EVAL(R.body)
+				// Evaluate the Rule at this position, saving the answer in the field "ans"
+				// Attempt to match the Pattern on this Derivation, saving the Result in the
+				// field "ans"
+				final Result ans = matchAndName(context);
+				ans.setType(getType());
+				ans.setAlias(isAlias());
 
-			ans.setLRStatus(m.getLRStatus());
-			context.setResultFor(this, ans, initialPosition);
+				ans.setLRStatus(m.getLRStatus());
+				context.setResultFor(this, ans, initialPosition);
 
-			// m.ans = ans
-			// Set the memoized answer equal to the answer from evaluating the rule at this
-			// position
-			// Set the memoized Rule's success equal to the success from evaluating the
-			// Pattern at this Derivation
-//			m.setSuccess(ans.isSuccess());
+				// m.ans = ans
+				// Set the memoized answer equal to the answer from evaluating the rule at this
+				// position
+				// Set the memoized Rule's success equal to the success from evaluating the
+				// Pattern at this Derivation
+//				m.setSuccess(ans.isSuccess());
 
-			// m.pos = Pos
-			// Set the memoized position equal to the current Position after evaluating the
-			// rule
-			// Set the memoized Derivation equal to the Derivation within the Result
-			// acquired from evaluating the Pattern
-//			m.setDerivation(ans.getDerivation());
-
-			// if lr.detected and ans != FAIL
-			// If the answer from evaluating the rule says that it is left-recursive and it
-			// had a definite match when we finished evaluating it 3 lines of code up
-			// If the Result from evaluating the Pattern has a DETECTED LeftRecursionStatus
-			// and it has a successful match (seed) of the recursive pattern
-			if ((ans.getLRStatus() == LeftRecursionStatus.DETECTED) && ans.isSuccess()) {
-
-				// Log that we're going to start growing this left-recursive call
-				context.addHistory(new MetaMatchEvent(context, this, ans, MetaMatchEventType.BEGIN_GROW));
-
-				// return GROW-LR(R,P,m,NIL)
-				// return the result of growing the left-recursive rule until it cannot be
-				// re-evaluated to consume any more input
-				// return the result of growing the left-recursive Pattern until it cannot be
-				// re-evaluated to consume any more input
-				return growLeftRecursion(context, initialPosition);
-
-			} else {
-				// Set left recursion status to impossible, since we didn't get a simultaneous
-				// call while this branch executed
-				ans.setLRStatus(LeftRecursionStatus.IMPOSSIBLE);
-
-				// return ans
-				// Return the answer of the evaluation of the rule
-				// Return the Result of attmepting to match the Pattern
-				return ans;
-			}
-
-		} else {
-
-			// Log that we're going to delegate to using the saved result
-			context.addHistory(new MetaMatchEvent(context, this, m, MetaMatchEventType.ASSUME_RESULT));
-
-			// Pos = m.pos
-			// Set the current position of parsing equal to the result m's position
-			// If the result is a success, set the current position of the context equal to
-			// the result m's end index
-			if (m.isSuccess()) { // TODO: Ideally we comment this out
-				context.setPosition(m.getEndIdx());
-			}
-
-			// if m.ans is LR
-			// if the current memoised answer of the rule application is LR, then this else
-			// block was called
-			// while another instance of this method further up the stack trace is still
-			// trying to evaluate the rule
-			// after an initial creation of a possibly left-recursive memoised answer
-			// if the current memoised Result of the Pattern application has a
-			// LeftRecursiveStatus of POSSIBLY,
-			// then this iteration of lazyMatch() was called while another iteration further
-			// up the stack trace is still
-			// in the middle of the first evaluation of this rule at this position,
-			// meaning that this rule is definitely left-recursive at this position
-			if (m.getLRStatus() == LeftRecursionStatus.POSSIBLE) {
-				// m.ans.detected = TRUE
-				// Mark this rule at this position as left-recursive for sure
-				// Mark this Pattern at this Derivation as left-recursive for sure
-				m.setLRStatus(LeftRecursionStatus.DETECTED);
-
-				// Log that we identified a left-recursive call
-
-				// Log that we're flagging this result as left-recursive
-				context.addHistory(new MetaMatchEvent(context, this, m, MetaMatchEventType.IDENTIFY_LR));
-
-				// return FAIL
-				// end this iteration with a failure so that we can find a seed later on in the
+				// m.pos = Pos
+				// Set the memoized position equal to the current Position after evaluating the
 				// rule
-				// end this iteration with a failure so that we can find a seed later on in the
-				// Pattern
-				assert !m.isSuccess();
-			} else {
-				// return m.ans
-				// Return the answer of applying the rule at this position
-				// Return the Result of applying the rule at this position
-			}
+				// Set the memoized Derivation equal to the Derivation within the Result
+				// acquired from evaluating the Pattern
+//				m.setDerivation(ans.getDerivation());
 
-			// Return the result of applying the rule at this position
-			return m;
+				// if lr.detected and ans != FAIL
+				// If the answer from evaluating the rule says that it is left-recursive and it
+				// had a definite match when we finished evaluating it 3 lines of code up
+				// If the Result from evaluating the Pattern has a DETECTED LeftRecursionStatus
+				// and it has a successful match (seed) of the recursive pattern
+				if ((ans.getLRStatus() == LeftRecursionStatus.DETECTED) && ans.isSuccess()) {
+
+					// Log that we're going to start growing this left-recursive call
+					context.addHistory(new MetaMatchEvent(context, this, ans, MetaMatchEventType.BEGIN_GROW));
+
+					// return GROW-LR(R,P,m,NIL)
+					// return the result of growing the left-recursive rule until it cannot be
+					// re-evaluated to consume any more input
+					// return the result of growing the left-recursive Pattern until it cannot be
+					// re-evaluated to consume any more input
+					return growLeftRecursion(context, initialPosition);
+
+				} else {
+					// Set left recursion status to impossible, since we didn't get a simultaneous
+					// call while this branch executed
+					ans.setLRStatus(LeftRecursionStatus.IMPOSSIBLE);
+
+					// return ans
+					// Return the answer of the evaluation of the rule
+					// Return the Result of attmepting to match the Pattern
+					return ans;
+				}
+
+			} else {
+
+				// Log that we're going to delegate to using the saved result
+				context.addHistory(new MetaMatchEvent(context, this, m, MetaMatchEventType.ASSUME_RESULT));
+
+				// Pos = m.pos
+				// Set the current position of parsing equal to the result m's position
+				// If the result is a success, set the current position of the context equal to
+				// the result m's end index
+				if (m.isSuccess()) { // TODO: Ideally we comment this out
+					context.setPosition(m.getEndIdx());
+				}
+
+				// if m.ans is LR
+				// if the current memoised answer of the rule application is LR, then this else
+				// block was called
+				// while another instance of this method further up the stack trace is still
+				// trying to evaluate the rule
+				// after an initial creation of a possibly left-recursive memoised answer
+				// if the current memoised Result of the Pattern application has a
+				// LeftRecursiveStatus of POSSIBLY,
+				// then this iteration of lazyMatch() was called while another iteration further
+				// up the stack trace is still
+				// in the middle of the first evaluation of this rule at this position,
+				// meaning that this rule is definitely left-recursive at this position
+				if (m.getLRStatus() == LeftRecursionStatus.POSSIBLE) {
+					// m.ans.detected = TRUE
+					// Mark this rule at this position as left-recursive for sure
+					// Mark this Pattern at this Derivation as left-recursive for sure
+					m.setLRStatus(LeftRecursionStatus.DETECTED);
+
+					// Log that we identified a left-recursive call
+
+					// Log that we're flagging this result as left-recursive
+					context.addHistory(new MetaMatchEvent(context, this, m, MetaMatchEventType.IDENTIFY_LR));
+
+					// return FAIL
+					// end this iteration with a failure so that we can find a seed later on in the
+					// rule
+					// end this iteration with a failure so that we can find a seed later on in the
+					// Pattern
+					assert !m.isSuccess();
+				} else {
+					// return m.ans
+					// Return the answer of applying the rule at this position
+					// Return the Result of applying the rule at this position
+				}
+
+				// Return the result of applying the rule at this position
+				return m;
+
+			}
 
 		}
 
-//		// Check for previously calculated Result
-//		if (derivation.hasSaved(this)) {
-//			return derivation.resultFor(this);
-//		}
-//
-//		// No previously-calculated Result, we gotta do it ourselves.
-//
-//		// Calculate result
-//		Result<?> result = match(derivation);
-//		// Save result
-//		derivation.setResultFor(this, result);
-//		// Return result
-//		return result;
 	}
 
 	/**

--- a/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/Pattern.java
+++ b/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/Pattern.java
@@ -10,7 +10,6 @@ import edu.ncsu.csc499.peg_lr.event.pattern.MetaMatchEvent.MetaMatchEventType;
 import edu.ncsu.csc499.peg_lr.event.pattern.PatternMatchEvent;
 import edu.ncsu.csc499.peg_lr.structure.InputContext;
 import edu.ncsu.csc499.peg_lr.structure.Result;
-import edu.ncsu.csc499.peg_lr.structure.Result.LeftRecursionStatus;
 
 public abstract class Pattern {
 
@@ -228,8 +227,6 @@ public abstract class Pattern {
 			// Start matching from this current derivation we're given
 			// Attempt to *match* the Pattern (this one) against the Derivation
 			attempt = matchAndName(context);
-			// Ensure that this attempt is labeled as left-recursive
-			attempt.setLRStatus(LeftRecursionStatus.DETECTED);
 
 			// If we didn't make any progress, then exit
 			if (!attempt.isSuccess()) {

--- a/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/structure/InputContext.java
+++ b/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/structure/InputContext.java
@@ -131,6 +131,11 @@ public class InputContext {
 		return this.position == this.inputString.length();
 	}
 
+	/**
+	 * Returns the total length of the input string.
+	 *
+	 * @return the number of characters in the input string
+	 */
 	public int length() {
 		return inputString.length();
 	}
@@ -283,6 +288,47 @@ public class InputContext {
 		final Result r = this.patterns.get(index).get(p);
 		addHistory(new MemoryEvent(this, MemoryEventType.CHECK, p, r, index));
 		return r;
+	}
+
+	/**
+	 * Clears the specified pattern from the growing map at the specified index.
+	 *
+	 * @param p the pattern to clear
+	 */
+	public void clearResult(final Pattern p) {
+		clearResult(p, getPosition());
+	}
+
+	/**
+	 * Clears the specified pattern from the growing map at the specified index.
+	 *
+	 * @param p     the pattern to clear
+	 * @param index the index to clear of the pattern
+	 */
+	public void clearResult(final Pattern p, final int index) {
+		addHistory(new MemoryEvent(this, MemoryEventType.CLEAR, p, null, index));
+		patterns.get(index).remove(p);
+	}
+
+	/**
+	 * Returns the number of patterns that are registered with seeds at the current
+	 * position
+	 *
+	 * @return the number of patterns that have a saved seed at this index
+	 */
+	public int getResultCount() {
+		return getResultCount(getPosition());
+	}
+
+	/**
+	 * Returns the number of patterns that are registered with seeds at the given
+	 * position
+	 *
+	 * @param index the index to check
+	 * @return the number of patterns that have a saved seed at this index
+	 */
+	public int getResultCount(final int index) {
+		return patterns.get(index).size();
 	}
 
 	/**

--- a/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/structure/Result.java
+++ b/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/structure/Result.java
@@ -26,9 +26,6 @@ public class Result {
 	 */
 	private boolean alias;
 
-	/** The left-recursion status of this Result. */
-	private LeftRecursionStatus lRStatus;
-
 	/** The sub-matches within this Result. */
 	private final List<Result> children;
 	{
@@ -46,7 +43,6 @@ public class Result {
 		final Result fail = new Result(idx);
 		fail.setAlias(false);
 		fail.setSuccess(false);
-		fail.setLRStatus(LeftRecursionStatus.IMPOSSIBLE);
 		return fail;
 	}
 
@@ -78,7 +74,7 @@ public class Result {
 	 * @param startIdx the index that the data was matched at in the input string
 	 */
 	public Result(final String data, final int startIdx) {
-		this(true, data, startIdx, LeftRecursionStatus.POSSIBLE);
+		this(true, data, startIdx);
 	}
 
 	/**
@@ -91,11 +87,9 @@ public class Result {
 	 * @param leftRecursionStatus the known recursion status of this Result
 	 * @throws NullPointerException if data is null
 	 */
-	public Result(final boolean success, final String data, final int startIdx,
-			final LeftRecursionStatus leftRecursionStatus) {
+	public Result(final boolean success, final String data, final int startIdx) {
 		setSuccess(success);
 		setData(data);
-		setLRStatus(leftRecursionStatus);
 		setStartIdx(startIdx);
 		setEndIdx(startIdx + data.length());
 	}
@@ -164,20 +158,6 @@ public class Result {
 	 */
 	public void setData(final String data) {
 		this.data = data;
-	}
-
-	/**
-	 * @return the lRStatus
-	 */
-	public LeftRecursionStatus getLRStatus() {
-		return lRStatus;
-	}
-
-	/**
-	 * @param lRStatus the lRStatus to set
-	 */
-	public void setLRStatus(final LeftRecursionStatus lRStatus) {
-		this.lRStatus = lRStatus;
 	}
 
 	/**
@@ -259,7 +239,7 @@ public class Result {
 	@Override
 	public String toString() {
 		return "Result [success=" + success + ", data=" + data + ", type=" + type + ", startIdx=" + startIdx
-				+ ", endIdx=" + endIdx + ", lRStatus=" + lRStatus + "]";
+				+ ", endIdx=" + endIdx + "]";
 	}
 
 	/**
@@ -346,9 +326,6 @@ public class Result {
 
 		tree.append(tabs(indentLevel + 1)).append("\"data\": \"").append(data).append("\",\n");
 
-		tree.append(tabs(indentLevel + 1)).append("\"left_recursion\": \"").append(this.getLRStatus().toString())
-				.append("\",\n");
-
 		tree.append(tabs(indentLevel + 1)).append("\"s\": ").append(startIdx + 1).append(",\n");
 
 		tree.append(tabs(indentLevel + 1)).append("\"e\": ").append(endIdx + 1).append(children.isEmpty() ? "" : ",")
@@ -378,61 +355,6 @@ public class Result {
 
 	private String tabs(final int num) {
 		return "  ".repeat(num);
-	}
-
-	/**
-	 * Possible options for the result of a Pattern at any given position. A Pattern
-	 * can have left recursion be possible, detected, or impossible.
-	 * 
-	 * @author Melody Griesen
-	 *
-	 */
-	public enum LeftRecursionStatus {
-		/**
-		 * The Pattern at this Derivation *might* be left-recursive. We'll know after it
-		 * finishes matching once.
-		 */
-		POSSIBLE("Possible"),
-		/**
-		 * The Pattern at this Derivation is definitely left-recursive. It called itself
-		 * before we had a chance to finish its first match.
-		 */
-		DETECTED("Detected"),
-		/**
-		 * The Pattern at this Derivation is not left-recursive. We finished one full
-		 * match without it calling itself.
-		 */
-		IMPOSSIBLE("Impossible");
-
-		/** Display-friendly name for this enum value */
-		private String displayName;
-
-		/**
-		 * Constructs an enum value with a display-friendly name
-		 *
-		 * @param displayName display-friendly name for this value
-		 */
-		LeftRecursionStatus(final String displayName) {
-			this.displayName = displayName;
-		}
-
-		/**
-		 * @return the enum's display name
-		 */
-		public String getDisplayName() {
-			return displayName;
-		}
-
-		/**
-		 * Gets the display name of this Enum by indexing into the display names array
-		 * by the Enum's ordinal.
-		 * 
-		 * @return a display-friendly name for this Enum.
-		 */
-		@Override
-		public String toString() {
-			return getDisplayName();
-		}
 	}
 
 }

--- a/PEG Direct Left-Recursion Prototype/test/edu/ncsu/csc499/peg_lr/structure/ResultTest.java
+++ b/PEG Direct Left-Recursion Prototype/test/edu/ncsu/csc499/peg_lr/structure/ResultTest.java
@@ -4,8 +4,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import edu.ncsu.csc499.peg_lr.structure.Result.LeftRecursionStatus;
-
 public class ResultTest {
 
 	/** Test object */
@@ -38,9 +36,6 @@ public class ResultTest {
 		Assert.assertEquals(3, FAIL.getStartIdx());
 		Assert.assertEquals(3, FAIL.getEndIdx());
 
-		// not be left-recursive
-		Assert.assertEquals(LeftRecursionStatus.IMPOSSIBLE, FAIL.getLRStatus());
-
 		// be unique from another call to FAIL:
 		Assert.assertNotSame(Result.FAIL(3), FAIL);
 
@@ -59,7 +54,6 @@ public class ResultTest {
 		Assert.assertTrue(result.isHidden());
 		Assert.assertFalse(result.isAlias());
 		Assert.assertNull(result.getType());
-		Assert.assertEquals(LeftRecursionStatus.POSSIBLE, result.getLRStatus());
 	}
 
 	@Test
@@ -75,7 +69,6 @@ public class ResultTest {
 		Assert.assertTrue(result.isHidden());
 		Assert.assertFalse(result.isAlias());
 		Assert.assertNull(result.getType());
-		Assert.assertEquals(LeftRecursionStatus.POSSIBLE, result.getLRStatus());
 	}
 
 	@Test
@@ -91,13 +84,12 @@ public class ResultTest {
 		Assert.assertTrue(result.isHidden());
 		Assert.assertFalse(result.isAlias());
 		Assert.assertNull(result.getType());
-		Assert.assertEquals(LeftRecursionStatus.POSSIBLE, result.getLRStatus());
 	}
 
 	@Test
 	public void testConstructorFull() {
 		// Construct successful result with data "asdf" at idx 1
-		result = new Result(true, "asdf", 1, LeftRecursionStatus.IMPOSSIBLE);
+		result = new Result(true, "asdf", 1);
 
 		// Ensure desired properties
 		Assert.assertTrue(result.isSuccess());
@@ -107,10 +99,9 @@ public class ResultTest {
 		Assert.assertTrue(result.isHidden());
 		Assert.assertFalse(result.isAlias());
 		Assert.assertNull(result.getType());
-		Assert.assertEquals(LeftRecursionStatus.IMPOSSIBLE, result.getLRStatus());
 
 		// Construct failed result with data "" at idx 1
-		result = new Result(false, "", 1, LeftRecursionStatus.IMPOSSIBLE);
+		result = new Result(false, "", 1);
 
 		// Ensure desired properties
 		Assert.assertFalse(result.isSuccess());
@@ -120,7 +111,6 @@ public class ResultTest {
 		Assert.assertTrue(result.isHidden());
 		Assert.assertFalse(result.isAlias());
 		Assert.assertNull(result.getType());
-		Assert.assertEquals(LeftRecursionStatus.IMPOSSIBLE, result.getLRStatus());
 	}
 
 	@Test
@@ -225,7 +215,6 @@ public class ResultTest {
 		Assert.assertTrue(toString.contains("" + result.getType()));
 		Assert.assertTrue(toString.contains("" + result.getStartIdx()));
 		Assert.assertTrue(toString.contains("" + result.getEndIdx()));
-		Assert.assertTrue(toString.contains(result.getLRStatus().toString()));
 	}
 
 }

--- a/PEG Direct Left-Recursion Prototype/test/edu/ncsu/csc499/peg_lr/util/PatternTestUtils.java
+++ b/PEG Direct Left-Recursion Prototype/test/edu/ncsu/csc499/peg_lr/util/PatternTestUtils.java
@@ -202,6 +202,11 @@ public class PatternTestUtils {
 				Assert.assertTrue(scenario + "Failure: Input string was not exhausted.", matcher.context.isAtEnd());
 			}
 		}
+
+		// Ensure that the context growing map was cleared out all the way
+		for (int i = 0; i <= matcher.context.length(); i++) {
+			Assert.assertEquals(0, matcher.context.getResultCount(i));
+		}
 	}
 
 	/**


### PR DESCRIPTION
Re-implements the main Pattern.lazyMatch() method to rely on static left-recursion detection rather than dynamic left-recursion detection.
This moves our prototype closer to Rosie's VM and allows us to work more closely on testing some edge cases in the current LR algorithm.
Bonus - That messy `leftRecursionStatus` field is no more! Now that we can just call a method to see if a pattern is left-recursive, we don't need that status to tell us what's recursive and what isn't.

Fixes #16 (finally!)