### PR TITLE
Correct DefinedPattern skipping top-level definition pattern in full result tree

### DIFF
--- a/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/definition/DefinedPattern.java
+++ b/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/definition/DefinedPattern.java
@@ -53,10 +53,18 @@ public class DefinedPattern extends Pattern {
 		final Result overallResult = new Result(context.getPosition());
 		// Delegate to the pattern we created.
 		final Result definitionResult = getPattern().lazyMatch(context);
-		// Add that result to our onw
-		overallResult.addChild(definitionResult);
-		// Return the overall result for this definition
-		return overallResult;
+		// If it was successful
+		if (definitionResult.isSuccess()) {
+			// Add that result to our own
+			overallResult.addChild(definitionResult);
+			// Return the overall result for this definition
+			return overallResult;
+		}
+		// Otherwise, it wasn't successful
+		else {
+			// Just return the definition match
+			return definitionResult;
+		}
 	}
 
 	/**

--- a/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/definition/DefinedPattern.java
+++ b/PEG Direct Left-Recursion Prototype/src/edu/ncsu/csc499/peg_lr/pattern/definition/DefinedPattern.java
@@ -24,6 +24,7 @@ public class DefinedPattern extends Pattern {
 
 	/**
 	 * Creates a DefinedPattern with the given pattern definition and type name.
+	 *
 	 * @param type       the type name of the Pattern being defined
 	 * @param definition the internal Pattern that will be used upon matching
 	 */
@@ -48,8 +49,14 @@ public class DefinedPattern extends Pattern {
 	 */
 	@Override
 	protected Result match(final InputContext context) {
+		// Create a Result for the pattern we'll match
+		final Result overallResult = new Result(context.getPosition());
 		// Delegate to the pattern we created.
-		return getPattern().lazyMatch(context);
+		final Result definitionResult = getPattern().lazyMatch(context);
+		// Add that result to our onw
+		overallResult.addChild(definitionResult);
+		// Return the overall result for this definition
+		return overallResult;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #44 by creating a parent Result for DefinedPattern within its match() method